### PR TITLE
fix(vercel): pin pnpm 11 + mark mermaid as server external

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Versão lida automaticamente de package.json#packageManager (pnpm@11.x)
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - uses: actions/setup-node@v4
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -7,3 +7,13 @@ public-hoist-pattern[]=next
 # zod como peerDependency, então o resolver não encontra a subpath pelo walk-up
 # do .pnpm. Manter zod também como devDep da raiz garante o hoist.
 public-hoist-pattern[]=zod
+
+# Hoist langium e vscode-*: langium é dep transitiva de mermaid e tem deep
+# imports de vscode-jsonrpc / vscode-languageserver-* (peer deps que não
+# vivem na pasta isolada do langium no .pnpm). Sem hoist, Turbopack falha
+# em "Module not found" no build de production.
+public-hoist-pattern[]=langium
+public-hoist-pattern[]=vscode-jsonrpc
+public-hoist-pattern[]=vscode-languageserver-protocol
+public-hoist-pattern[]=vscode-languageserver-types
+public-hoist-pattern[]=vscode-languageserver-textdocument

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,6 +2,16 @@
 const nextConfig = {
   output: 'standalone',
   allowedDevOrigins: ["127.0.0.1", "localhost"],
+  // mermaid + langium têm deep imports de vscode-jsonrpc/languageserver-* que
+  // Turbopack não consegue resolver pelo walk-up do .pnpm. Como mermaid já é
+  // carregado lazy em components/mdx/mermaid-block.tsx (dynamic import dentro
+  // de useEffect, só roda no client), basta marcá-los como externals do server
+  // pra Turbopack não tentar fazer o bundle dessa cadeia.
+  serverExternalPackages: [
+    "mermaid",
+    "@mermaid-js/parser",
+    "langium",
+  ],
   // Keystatic lê YAML em runtime; o trace serverless da Vercel pode não os
   // incluir nas revalidações ISR — sem isto, carreiras/projetos/redes podem
   // aparecer vazios em produção.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   },
   "devDependencies": {
     "next": "16.2.1",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "vscode-jsonrpc": "^8.2.0",
+    "vscode-languageserver-protocol": "^3.17.5",
+    "vscode-languageserver-types": "^3.17.5",
+    "vscode-languageserver-textdocument": "^1.0.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "piluvitu-monorepo",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "pnpm@11.1.1",
   "scripts": {
     "dev": "pnpm --filter @piluvitu/web dev",
     "build": "pnpm --filter @piluvitu/web build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       next:
         specifier: 16.2.1
         version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      vscode-jsonrpc:
+        specifier: ^8.2.0
+        version: 8.2.0
+      vscode-languageserver-protocol:
+        specifier: ^3.17.5
+        version: 3.17.5
+      vscode-languageserver-textdocument:
+        specifier: ^1.0.11
+        version: 1.0.12
+      vscode-languageserver-types:
+        specifier: ^3.17.5
+        version: 3.17.5
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary

Resolve a falha do deploy de production na Vercel após o merge do PR #29 do monorepo. Substitui o PR #30 que ficou com conflitos após o squash merge.

- **pnpm version**: Vercel detectou pnpm 9.x baseado na data do projeto, mas o lockfile é v11. Adicionado `packageManager: pnpm@11.1.1` no root package.json — corepack passa a usar a versão certa.
- **mermaid build**: Turbopack não resolvia `vscode-jsonrpc`/`vscode-languageserver-*` (deps internas de `langium`, transitiva de `mermaid`). Como `mermaid-block.tsx` já carrega mermaid lazy via dynamic import dentro de useEffect (só client), basta marcar como `serverExternalPackages` pra Turbopack não empacotar a cadeia no SSR.

## Test plan

- [x] `pnpm --filter @piluvitu/web build:ci` local → OK, todas rotas geradas
- [ ] Aguardando Vercel deploy de production passar