### PR TITLE
feat(web): Design System V2 'Cloud (cyan)' foundation (tokens + fonts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,10 @@ O tema é o **Design System V2 "Cloud (cyan)"** — dark-first, acento ciano. Os
 - **Verificação visual:** story `components/design-tokens.stories.tsx` (paleta/tipografia/forma).
 - **Spec/plano:** `docs/superpowers/specs/2026-06-02-design-system-v2-foundation-design.md` + `docs/superpowers/plans/2026-06-02-design-system-v2-foundation.md`. Escopo entregue = **fundação** (tokens + fontes); reskin página a página fica pra depois.
 
+### Home V2 (DS V2 reskin)
+
+A home (`/`) foi completamente reskinada para o DS V2. **Layout (`page.tsx`):** scroll da página inteira (sem overflow independente de coluna) — a coluna esquerda do perfil (`col-span-4`) é `xl:sticky xl:top-10 xl:self-start` e fica fixa por todo o scroll (é mais baixa que a viewport), enquanto a direita (`col-span-8`) flui normalmente e é o que "rola". O grid usa `xl:items-start` (necessário pro sticky). O `HomeFooter` fica **fora** do grid, full-width, no fim do scroll (cobre as duas colunas) — não dentro da coluna direita. No mobile (`< xl`) tudo empilha em `flex flex-col`. Novos componentes: `SectionHeader` (título + ação + divider), `HomeFooter` (rodapé inline com mailto), cards V2 (`JobCard` com modal de "Atribuições", `ProjectCard` com subtitle, `ArticleCard` com métricas). Social strip com email icon → mailto. O container raiz usa `2xl:max-w-[1180px]` + glow decorativo ciano fixo no topo (`--color-accent-soft` radial-gradient). Novos campos Keystatic: perfil (`availabilityOpen`/`availabilityLabel`/`location`/`disciplines`), carreira (`current`/`tags`), projeto (`subtitle`). Smoke test E2E em `app/(site)/home.e2e.ts`. Spec: `docs/superpowers/specs/2026-06-02-home-v2-reskin-design.md`.
+
 ### Blog (TinaCMS)
 
 - **Content repo**: `PiluVitu/piluvitu-blog` (private) — MDX files at `content/posts/*.mdx`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,14 @@ Permitted image hosts are configured in `next.config.mjs` (`images.remotePattern
 
 ### Theme
 
-Custom `--success` / `--success-foreground` CSS variables in `app/globals.css` expose `text-success` via Tailwind. Used for positive metric indicators (e.g., article reactions > 0).
+O tema é o **Design System V2 "Cloud (cyan)"** — dark-first, acento ciano. Os valores vivem em `app/globals.css` (`:root` = variante light derivada, `.dark` = "Cloud" dark) mapeados sobre os tokens shadcn existentes: a cor de marca do V2 (ciano `#38bdf8`) entra como `--primary` (atenção: no shadcn `--accent` é o hover bg, não a marca). **Dark é o padrão** via `next-themes` (`defaultTheme="dark"` em `app/(site)/layout.tsx`); o `mode-toggle` alterna pro light.
+
+- **Fontes:** Plus Jakarta Sans (corpo/títulos, `--font-sans`) + JetBrains Mono (labels/datas/tags, `--font-mono`), via `next/font` no `app/layout.tsx`. O fallback fica aninhado no `var()` (`var(--font-plus-jakarta, ui-sans-serif, …)`) pra sobreviver onde o RootLayout não roda (ex.: Storybook).
+- **Tokens semânticos (votação):** `--ok` (sucesso/seu voto), `--warn` (empate/atenção), `--win` (vencedor) expostos como `text-ok`/`bg-warn`/`text-win` etc. `--success`/`--success-foreground` são mantidos como espelho de `--ok` (compat com usos existentes de `text-success`).
+- **Marca translúcida:** `--color-accent-soft` / `--color-accent-line` (estáticos sky-400, não derivam de `--primary`) → `bg-accent-soft` / `border-accent-line`.
+- **Forma:** `--radius` 18px (cards macios), `--radius-pill` 999px (`rounded-pill`), `--shadow-ds` (`shadow-ds`).
+- **Verificação visual:** story `components/design-tokens.stories.tsx` (paleta/tipografia/forma).
+- **Spec/plano:** `docs/superpowers/specs/2026-06-02-design-system-v2-foundation-design.md` + `docs/superpowers/plans/2026-06-02-design-system-v2-foundation.md`. Escopo entregue = **fundação** (tokens + fontes); reskin página a página fica pra depois.
 
 ### Blog (TinaCMS)
 

--- a/apps/web/app/(site)/home.e2e.ts
+++ b/apps/web/app/(site)/home.e2e.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Home V2', () => {
+  test('mostra perfil, seções e abre o modal de carreira', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Paulo Victor/i }),
+    ).toBeVisible()
+
+    await expect(page.getByRole('heading', { name: 'Carreira' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Projetos' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Artigos' })).toBeVisible()
+
+    await page
+      .getByRole('button', { name: /detalhes/i })
+      .first()
+      .click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText('Atribuições')).toBeVisible()
+  })
+})

--- a/apps/web/app/(site)/page.tsx
+++ b/apps/web/app/(site)/page.tsx
@@ -1,5 +1,6 @@
 import { Bio } from '@/components/bio'
 import { HomeBentoLayout } from '@/components/home-bento-layout'
+import { HomeFooter } from '@/components/home-footer'
 import { getLatestDevToArticleUrl } from '@/lib/dev-to'
 import {
   getCarreiras,
@@ -25,6 +26,10 @@ const fallbackProfile: SiteProfileContent = {
   companyLink: 'https://www.viralizeplus.com.br/',
   companyLinkColor: '#4a65fc',
   bio: 'DevOps Engineer com 3 anos de experiência focado em garantir que sistemas em nuvem operem com alta disponibilidade e custo eficiente. Especialista em transformar operações manuais em processos automatizados e seguros, utilizando ferramentas de mercado para monitorar a saúde das aplicações em tempo real e antecipar falhas antes que afetem o usuário final.',
+  availabilityOpen: true,
+  availabilityLabel: 'Disponível para oportunidades',
+  location: 'Brasil · Remoto',
+  disciplines: ['SRE', 'DevOps', 'Cloud'],
 }
 
 export default async function Home() {
@@ -54,25 +59,33 @@ export default async function Home() {
   const initialBlogPosts = blogPosts.map(blogPostToView)
 
   return (
-    <div className="min-h-screen pt-2 pr-4 pb-2 pl-6 sm:pr-4 sm:pl-8 xl:grid xl:h-screen xl:max-h-screen xl:min-h-0 xl:grid-cols-12 xl:grid-rows-1 xl:items-stretch xl:gap-10 xl:overflow-hidden xl:pt-10 xl:pr-8 xl:pb-4 xl:pl-14 2xl:mx-auto 2xl:max-w-[1920px]">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-16 pb-4 xl:contents xl:max-w-none">
+    <div className="min-h-screen px-6 pt-2 pb-4 sm:px-8 xl:px-14 xl:pt-10 xl:pb-4 2xl:mx-auto 2xl:max-w-[1180px]">
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-x-0 top-0 -z-10 h-[600px] bg-[radial-gradient(60%_60%_at_50%_0%,var(--color-accent-soft),transparent)]"
+      />
+
+      {/*
+        Scroll da página inteira. A coluna esquerda é `sticky` (mais baixa que a
+        viewport → fica fixa por todo o scroll). A direita flui normalmente e é o
+        que "rola". O footer (abaixo do grid) é full-width e só aparece no fim.
+      */}
+      <div className="mx-auto flex w-full max-w-md flex-col gap-16 xl:mx-0 xl:grid xl:max-w-none xl:grid-cols-12 xl:items-start xl:gap-10">
         <main
           id="profile"
-          className="col-span-12 flex min-h-0 flex-col items-start xl:col-span-4 xl:overflow-y-auto xl:overscroll-y-contain xl:pr-2"
+          className="flex flex-col items-start xl:sticky xl:top-10 xl:col-span-4 xl:self-start"
           suppressHydrationWarning
         >
-          <header className="flex flex-col gap-6">
-            <Bio
-              profile={siteProfile}
-              socials={socialList}
-              latestDevArticleUrl={latestDevArticleUrl}
-              visitCard={visitCard}
-            />
-          </header>
+          <Bio
+            profile={siteProfile}
+            socials={socialList}
+            latestDevArticleUrl={latestDevArticleUrl}
+            visitCard={visitCard}
+          />
         </main>
         <aside
-          id="left-side"
-          className="flex min-h-0 flex-col pb-4 xl:col-span-8 xl:overflow-y-auto xl:overscroll-y-contain xl:pr-1 xl:pb-4"
+          id="content"
+          className="flex flex-col xl:col-span-8 xl:pb-6"
           suppressHydrationWarning
         >
           <HomeBentoLayout
@@ -81,6 +94,11 @@ export default async function Home() {
             initialBlogPosts={initialBlogPosts}
           />
         </aside>
+      </div>
+
+      {/* Footer full-width (cobre as duas colunas), no fim do scroll */}
+      <div className="mx-auto w-full max-w-md xl:max-w-none">
+        <HomeFooter name={siteProfile.displayName} />
       </div>
     </div>
   )

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -34,6 +34,8 @@
   --color-success: hsl(var(--success));
   --color-success-foreground: hsl(var(--success-foreground));
 
+  /* Semantic status tokens (votação): ok=sucesso/seu voto, warn=empate/atenção,
+     win=vencedor. --success é mantido como alias de --ok (compat). */
   --color-ok: hsl(var(--ok));
   --color-ok-foreground: hsl(var(--ok-foreground));
   --color-warn: hsl(var(--warn));
@@ -41,11 +43,14 @@
   --color-win: hsl(var(--win));
   --color-win-foreground: hsl(var(--win-foreground));
 
+  /* Brand translucent overlays — estáticos de propósito (sky-400, não derivam de --primary) */
   --color-accent-soft: rgb(56 189 248 / 0.13);
   --color-accent-line: rgb(56 189 248 / 0.32);
 
-  --font-sans: var(--font-plus-jakarta), ui-sans-serif, system-ui, sans-serif;
-  --font-mono: var(--font-jetbrains), ui-monospace, monospace;
+  /* Fallback aninhado no var(): se a var do next/font não existir (ex.: Storybook
+     sem RootLayout), a stack ui-sans-serif vale — sem cair pra serif do browser. */
+  --font-sans: var(--font-plus-jakarta, ui-sans-serif, system-ui, sans-serif);
+  --font-mono: var(--font-jetbrains, ui-monospace, monospace);
 
   --radius-pill: 999px;
   --shadow-ds: 0 18px 40px rgb(0 0 0 / 0.45);
@@ -147,7 +152,7 @@
     --success-foreground: 0 0% 100%;
     --ok: 158 64% 40%;
     --ok-foreground: 0 0% 100%;
-    --warn: 38 92% 45%;
+    --warn: 38 92% 38%;
     --warn-foreground: 0 0% 100%;
     --win: 255 60% 60%;
     --win-foreground: 0 0% 100%;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -34,6 +34,22 @@
   --color-success: hsl(var(--success));
   --color-success-foreground: hsl(var(--success-foreground));
 
+  --color-ok: hsl(var(--ok));
+  --color-ok-foreground: hsl(var(--ok-foreground));
+  --color-warn: hsl(var(--warn));
+  --color-warn-foreground: hsl(var(--warn-foreground));
+  --color-win: hsl(var(--win));
+  --color-win-foreground: hsl(var(--win-foreground));
+
+  --color-accent-soft: rgb(56 189 248 / 0.13);
+  --color-accent-line: rgb(56 189 248 / 0.32);
+
+  --font-sans: var(--font-plus-jakarta), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-jetbrains), ui-monospace, monospace;
+
+  --radius-pill: 999px;
+  --shadow-ds: 0 18px 40px rgb(0 0 0 / 0.45);
+
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
@@ -108,52 +124,64 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
+    --background: 220 50% 98%;
+    --foreground: 222 36% 9%;
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 222 36% 9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 346.8 77.2% 49.8%;
-    --primary-foreground: 355.7 100% 97.3%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 346.8 77.2% 49.8%;
-    --success: 142 76% 36%;
-    --success-foreground: 356 100% 97%;
-    --radius: 0.75rem;
+    --popover-foreground: 222 36% 9%;
+    --primary: 198 93% 60%;
+    --primary-foreground: 200 75% 6%;
+    --secondary: 216 42% 95%;
+    --secondary-foreground: 222 36% 9%;
+    --muted: 216 42% 95%;
+    --muted-foreground: 215 18% 35%;
+    --accent: 216 43% 93%;
+    --accent-foreground: 222 36% 9%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 216 30% 88%;
+    --input: 216 30% 88%;
+    --ring: 198 93% 60%;
+    --success: 158 64% 40%;
+    --success-foreground: 0 0% 100%;
+    --ok: 158 64% 40%;
+    --ok-foreground: 0 0% 100%;
+    --warn: 38 92% 45%;
+    --warn-foreground: 0 0% 100%;
+    --win: 255 60% 60%;
+    --win-foreground: 0 0% 100%;
+    --radius: 1.125rem;
   }
 
   .dark {
-    --background: 20 14.3% 4.1%;
-    --foreground: 0 0% 95%;
-    --card: 24 9.8% 10%;
-    --card-foreground: 0 0% 95%;
-    --popover: 0 0% 9%;
-    --popover-foreground: 0 0% 95%;
-    --primary: 346.8 77.2% 49.8%;
-    --primary-foreground: 355.7 100% 97.3%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 15%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 12 6.5% 15.1%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 85.7% 97.3%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 346.8 77.2% 49.8%;
-    --success: 142 71% 48%;
-    --success-foreground: 144 61% 12%;
+    --background: 220 33% 5%;
+    --foreground: 215 33% 93%;
+    --card: 222 36% 9%;
+    --card-foreground: 215 33% 93%;
+    --popover: 222 36% 9%;
+    --popover-foreground: 215 33% 93%;
+    --primary: 198 93% 60%;
+    --primary-foreground: 200 75% 6%;
+    --secondary: 221 35% 12%;
+    --secondary-foreground: 215 33% 93%;
+    --muted: 221 35% 12%;
+    --muted-foreground: 216 17% 64%;
+    --accent: 217 32% 14%;
+    --accent-foreground: 215 33% 93%;
+    --destructive: 0 91% 71%;
+    --destructive-foreground: 200 75% 6%;
+    --border: 205 40% 18%;
+    --input: 205 40% 18%;
+    --ring: 198 93% 60%;
+    --success: 158 64% 52%;
+    --success-foreground: 200 75% 6%;
+    --ok: 158 64% 52%;
+    --ok-foreground: 200 75% 6%;
+    --warn: 43 96% 56%;
+    --warn-foreground: 200 75% 6%;
+    --win: 255 92% 76%;
+    --win-foreground: 200 75% 6%;
   }
 }
 
@@ -163,7 +191,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,9 +1,18 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { Plus_Jakarta_Sans, JetBrains_Mono } from 'next/font/google'
 import { getCanonicalSiteUrl } from '@/lib/site-url'
 import './globals.css'
 
-const inter = Inter({ subsets: ['latin'] })
+const sans = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-plus-jakarta',
+  display: 'swap',
+})
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains',
+  display: 'swap',
+})
 
 const siteUrl = getCanonicalSiteUrl()
 const siteHostname = (() => {
@@ -89,10 +98,12 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="pt-BR" suppressHydrationWarning>
-      <body className={inter.className} suppressHydrationWarning>
-        {children}
-      </body>
+    <html
+      lang="pt-BR"
+      className={`${sans.variable} ${mono.variable}`}
+      suppressHydrationWarning
+    >
+      <body suppressHydrationWarning>{children}</body>
     </html>
   )
 }

--- a/apps/web/components/article-card.stories.tsx
+++ b/apps/web/components/article-card.stories.tsx
@@ -18,57 +18,28 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const ComImagem: Story = {
-  args: {
-    article: {
-      id: 'blog-como-usar-husky',
-      source: 'blog',
-      title: 'Como usar o husky para garantir a qualidade do seu código',
-      href: '/posts/como-usar-husky',
-      isExternal: false,
-      socialImage:
-        'https://media2.dev.to/dynamic/image/width=1000,height=500,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fexample.jpg',
-      readingTimeMinutes: 4,
-      reactionsCount: 0,
-      commentsCount: 0,
-      publishedAt: '2026-04-10T10:00:00.000Z',
-    },
-  },
+const baseArticle = {
+  id: 'blog-como-usar-husky',
+  source: 'blog' as const,
+  title: 'Como usar o Husky para garantir a qualidade do seu código',
+  href: '/posts/como-usar-husky',
+  isExternal: false,
+  socialImage: null,
+  readingTimeMinutes: 5,
+  reactionsCount: 0,
+  commentsCount: 0,
+  publishedAt: '2026-04-10T10:00:00.000Z',
 }
 
-export const SemImagem: Story = {
-  name: 'Sem imagem (fallback gerado)',
+export const Blog: Story = { args: { article: baseArticle, index: 0 } }
+export const DevTo: Story = {
   args: {
     article: {
-      id: 'blog-dicas-linux',
-      source: 'blog',
-      title: 'Dicas e configurações para seu sistema linux',
-      href: '/posts/dicas-linux',
-      isExternal: false,
-      socialImage: null,
-      readingTimeMinutes: 7,
-      reactionsCount: 0,
-      commentsCount: 0,
-      publishedAt: '2026-03-20T09:00:00.000Z',
+      ...baseArticle,
+      id: 'devto-1',
+      source: 'devto',
+      isExternal: true,
     },
-  },
-}
-
-export const TituloLongo: Story = {
-  name: 'Título longo (truncado)',
-  args: {
-    article: {
-      id: 'blog-titulo-muito-longo',
-      source: 'blog',
-      title:
-        'Instalando de maneira rápida e eficiente suas ferramentas no WSL Pt.2 com exemplos práticos',
-      href: '/posts/instalando-wsl-pt2',
-      isExternal: false,
-      socialImage: null,
-      readingTimeMinutes: 15,
-      reactionsCount: 0,
-      commentsCount: 0,
-      publishedAt: '2026-03-01T08:00:00.000Z',
-    },
+    index: 1,
   },
 }

--- a/apps/web/components/article-card.tsx
+++ b/apps/web/components/article-card.tsx
@@ -1,56 +1,43 @@
 import type { ArticleCardView } from '@/lib/article-feed'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import Link from 'next/link'
 
 type ArticleCardProps = {
   article: ArticleCardView
+  index?: number
   className?: string
 }
 
-export function ArticleCard({ article, className }: ArticleCardProps) {
+export function ArticleCard({ article, index, className }: ArticleCardProps) {
+  const kbd = article.source === 'devto' ? '~/dev' : '~/blog'
+  const post = index !== undefined ? String(index + 1).padStart(2, '0') : null
+
   return (
     <Link
       href={article.href}
       target={article.isExternal ? '_blank' : undefined}
       rel={article.isExternal ? 'noopener noreferrer nofollow' : undefined}
       className={cn(
-        'bg-card text-card-foreground border shadow-sm',
-        'flex h-fit w-full flex-col justify-between gap-4 rounded-3xl p-5 transition-all',
-        'hover:-translate-y-0.5 hover:shadow-md',
+        'group bg-card border-border flex h-full flex-col gap-4 rounded-lg border p-5 transition-colors',
+        'hover:bg-accent',
         'focus-visible:ring-ring focus-visible:ring-offset-background outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
         className,
       )}
     >
-      <section className="flex flex-col justify-center gap-4">
-        <h3 className="truncate text-xl">{article.title}</h3>
-        <p className="text-muted-foreground">
-          Tempo de leitura: {article.readingTimeMinutes}min
-        </p>
-      </section>
-      <div className="relative mx-auto flex h-fit w-72 max-w-full shrink-0 overflow-hidden rounded-lg border">
-        {article.socialImage ? (
-          <Image
-            alt=""
-            loading="lazy"
-            width={288}
-            height={144}
-            src={article.socialImage}
-            className="h-auto w-full object-cover object-center"
-          />
-        ) : (
-          <div
-            className="flex h-36 w-full flex-col items-start justify-end gap-2 bg-gradient-to-br from-slate-800 to-slate-950 p-4"
-            aria-hidden
-          >
-            <p className="line-clamp-3 text-sm leading-snug font-semibold text-white">
-              {article.title}
-            </p>
-            <span className="text-xs text-slate-400">
-              {article.readingTimeMinutes} min de leitura
-            </span>
-          </div>
-        )}
+      <div className="flex items-center gap-2 font-mono text-xs">
+        <span className="bg-accent-soft text-primary rounded px-1.5 py-0.5">
+          {kbd}
+        </span>
+        {post ? (
+          <span className="text-muted-foreground">· post {post}</span>
+        ) : null}
+      </div>
+      <h3 className="line-clamp-2 text-lg font-semibold">{article.title}</h3>
+      <div className="text-muted-foreground mt-auto flex items-center justify-between font-mono text-xs">
+        <span>{article.readingTimeMinutes} min de leitura</span>
+        <span className="text-primary transition-transform group-hover:translate-x-0.5">
+          ler →
+        </span>
       </div>
     </Link>
   )

--- a/apps/web/components/article-section.tsx
+++ b/apps/web/components/article-section.tsx
@@ -8,8 +8,8 @@ type ArticleSectionProps = {
 export function ArticleSection({ initialBlogPosts = [] }: ArticleSectionProps) {
   return (
     <>
-      {initialBlogPosts.map((article) => (
-        <ArticleCard key={article.id} article={article} />
+      {initialBlogPosts.map((article, i) => (
+        <ArticleCard key={article.id} article={article} index={i} />
       ))}
     </>
   )

--- a/apps/web/components/bio.tsx
+++ b/apps/web/components/bio.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+import { faBriefcase, faLocationDot } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import type { SiteProfileContent, VisitCardContent } from '@/lib/site-content'
 import type { Social } from '@/mocks/social'
 import { ModeToggle } from './mode-toggle'
@@ -20,24 +22,35 @@ export function Bio({
   visitCard,
 }: BioProps) {
   const companyHref = profile.companyLink.trim()
+  const hasMeta = Boolean(profile.location) || profile.disciplines.length > 0
 
   return (
-    <>
-      <ProfileVisitCard
-        profile={profile}
-        visitCard={visitCard}
-        latestDevArticleUrl={latestDevArticleUrl}
-      />
-      <section>
+    <div className="flex flex-col gap-6">
+      <div className="flex items-start justify-between gap-4">
+        <ProfileVisitCard
+          profile={profile}
+          visitCard={visitCard}
+          latestDevArticleUrl={latestDevArticleUrl}
+        />
         <ModeToggle />
-      </section>
-      <h1 className="text-4xl font-semibold tracking-tight">
+      </div>
+
+      {profile.availabilityOpen ? (
+        <p className="text-muted-foreground flex items-center gap-2 font-mono text-xs">
+          <span className="bg-ok size-2 rounded-full" aria-hidden />
+          {profile.availabilityLabel}
+        </p>
+      ) : null}
+
+      <h1 className="text-4xl font-bold tracking-tight xl:text-5xl">
         {profile.displayName}
       </h1>
 
-      <section className="flex flex-col gap-2">
+      <div className="flex flex-col gap-4">
         <p>
-          <strong className="text-lime-500">{profile.roleHighlight}</strong>
+          <strong className="text-primary font-semibold">
+            {profile.roleHighlight}
+          </strong>
           {profile.companyName.trim() ? (
             <>
               {' na '}
@@ -66,7 +79,31 @@ export function Bio({
         </p>
         <p className="text-muted-foreground text-pretty">{profile.bio}</p>
         <ProfileSocialStrip socials={socials} />
-      </section>
-    </>
+        {hasMeta ? (
+          <div className="text-muted-foreground flex flex-col gap-2 pt-2 font-mono text-sm">
+            {profile.location ? (
+              <span className="flex items-center gap-2">
+                <FontAwesomeIcon
+                  icon={faLocationDot}
+                  className="size-3.5"
+                  aria-hidden
+                />
+                {profile.location}
+              </span>
+            ) : null}
+            {profile.disciplines.length > 0 ? (
+              <span className="flex items-center gap-2">
+                <FontAwesomeIcon
+                  icon={faBriefcase}
+                  className="size-3.5"
+                  aria-hidden
+                />
+                {profile.disciplines.join(' · ')}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
   )
 }

--- a/apps/web/components/design-tokens.stories.tsx
+++ b/apps/web/components/design-tokens.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+
+const meta: Meta = {
+  title: 'Design System/Tokens',
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+}
+export default meta
+type Story = StoryObj
+
+function Swatch({ label, className }: { label: string; className: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div
+        className={`border-border h-16 w-full rounded-lg border ${className}`}
+      />
+      <span className="text-muted-foreground font-mono text-xs">{label}</span>
+    </div>
+  )
+}
+
+const colors: Array<{ label: string; className: string }> = [
+  { label: 'background', className: 'bg-background' },
+  { label: 'foreground', className: 'bg-foreground' },
+  { label: 'card', className: 'bg-card' },
+  { label: 'secondary', className: 'bg-secondary' },
+  { label: 'muted', className: 'bg-muted' },
+  { label: 'accent (hover)', className: 'bg-accent' },
+  { label: 'primary', className: 'bg-primary' },
+  { label: 'destructive', className: 'bg-destructive' },
+  { label: 'ok', className: 'bg-ok' },
+  { label: 'warn', className: 'bg-warn' },
+  { label: 'win', className: 'bg-win' },
+  { label: 'accent-soft', className: 'bg-accent-soft' },
+]
+
+export const Colors: Story = {
+  render: () => (
+    <div className="bg-background p-8">
+      <h2 className="text-foreground mb-4 text-lg font-semibold">Cores</h2>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {colors.map((c) => (
+          <Swatch key={c.label} label={c.label} className={c.className} />
+        ))}
+      </div>
+    </div>
+  ),
+}
+
+export const Typography: Story = {
+  render: () => (
+    <div className="bg-background text-foreground space-y-4 p-8">
+      <p className="font-sans text-3xl font-bold">
+        Plus Jakarta Sans — Display
+      </p>
+      <p className="font-sans text-base">
+        Plus Jakarta Sans — corpo de leitura confortável.
+      </p>
+      <p className="text-muted-foreground font-mono text-sm">
+        JetBrains Mono — labels · metadados · 2026-06-02
+      </p>
+    </div>
+  ),
+}
+
+export const ShapeAndShadow: Story = {
+  render: () => (
+    <div className="bg-background flex flex-wrap items-end gap-6 p-8">
+      <div className="bg-card text-card-foreground shadow-ds flex h-32 w-48 items-center justify-center rounded-lg">
+        rounded-lg (18px) + shadow-ds
+      </div>
+      <span className="rounded-pill bg-primary text-primary-foreground px-4 py-1 text-sm">
+        rounded-pill
+      </span>
+    </div>
+  ),
+}

--- a/apps/web/components/home-bento-layout.tsx
+++ b/apps/web/components/home-bento-layout.tsx
@@ -1,6 +1,7 @@
 import { ArticleSection } from '@/components/article-section'
 import { JobCard } from '@/components/job-card'
 import { ProjectCard } from '@/components/project-card'
+import { SectionHeader } from '@/components/section-header'
 import type { ArticleCardView } from '@/lib/article-feed'
 import type { Carreira } from '@/mocks/carreira'
 import type { Project } from '@/mocks/projects'
@@ -11,10 +12,6 @@ type HomeBentoLayoutProps = {
   initialBlogPosts: ArticleCardView[]
 }
 
-/**
- * Arranjo estilo “bento” (referência tipo Kasbu): grelha com células de tamanhos
- * combinados, cantos muito arredondados e secções claras (Carreira → Projetos → Artigos).
- */
 export function HomeBentoLayout({
   carreiraList,
   projectList,
@@ -24,16 +21,15 @@ export function HomeBentoLayout({
     <div className="flex min-h-0 flex-col gap-10 xl:gap-12">
       <section
         aria-labelledby="carreira-heading"
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-5"
         suppressHydrationWarning
       >
-        <h2
+        <SectionHeader
           id="carreira-heading"
-          className="text-xl font-semibold tracking-tight"
-        >
-          Carreira
-        </h2>
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+          label="Carreira"
+          count={carreiraList.length}
+        />
+        <div className="grid grid-cols-1 gap-3.5 xl:grid-cols-2">
           {carreiraList.map((carreira) => (
             <JobCard key={carreira.id} {...carreira} />
           ))}
@@ -42,37 +38,31 @@ export function HomeBentoLayout({
 
       <section
         aria-labelledby="projetos-heading"
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-5"
         suppressHydrationWarning
       >
-        <h2
+        <SectionHeader
           id="projetos-heading"
-          className="text-xl font-semibold tracking-tight"
-        >
-          Projetos
-        </h2>
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+          label="Projetos"
+          count={projectList.length}
+        />
+        <div className="grid grid-cols-1 gap-6">
           {projectList.map((project) => (
-            <ProjectCard
-              key={project.id}
-              className="w-full xl:w-full"
-              {...project}
-            />
+            <ProjectCard key={project.id} {...project} />
           ))}
         </div>
       </section>
 
       <section
         aria-labelledby="artigos-heading"
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-5"
         suppressHydrationWarning
       >
-        <h2
+        <SectionHeader
           id="artigos-heading"
-          className="text-xl font-semibold tracking-tight"
-        >
-          Artigos
-        </h2>
+          label="Artigos"
+          count={initialBlogPosts.length}
+        />
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
           <ArticleSection initialBlogPosts={initialBlogPosts} />
         </div>

--- a/apps/web/components/home-footer.stories.tsx
+++ b/apps/web/components/home-footer.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { HomeFooter } from './home-footer'
+
+const meta: Meta<typeof HomeFooter> = {
+  title: 'Home/HomeFooter',
+  component: HomeFooter,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+}
+export default meta
+type Story = StoryObj<typeof HomeFooter>
+
+export const Default: Story = {
+  args: { name: 'Paulo Victor Torres Silva', year: 2026 },
+}

--- a/apps/web/components/home-footer.tsx
+++ b/apps/web/components/home-footer.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+
+type HomeFooterProps = {
+  name: string
+  year?: number
+}
+
+export function HomeFooter({
+  name,
+  year = new Date().getFullYear(),
+}: HomeFooterProps) {
+  return (
+    <footer className="text-muted-foreground border-border mt-2 flex flex-col gap-2 border-t pt-6 font-mono text-xs sm:flex-row sm:items-center sm:justify-between">
+      <span>
+        © {year} {name}
+      </span>
+      <span className="flex flex-wrap items-center gap-x-2">
+        <span>piluvitu.com.br</span>
+        <span aria-hidden>·</span>
+        <Link href="/tools" className="hover:text-foreground transition-colors">
+          /tools
+        </Link>
+        <span aria-hidden>·</span>
+        <Link
+          href="/votacao"
+          className="hover:text-foreground transition-colors"
+        >
+          /votação
+        </Link>
+        <span aria-hidden>·</span>
+        <Link
+          href="/votacao/admin"
+          className="hover:text-foreground transition-colors"
+        >
+          admin
+        </Link>
+      </span>
+    </footer>
+  )
+}

--- a/apps/web/components/job-card.stories.tsx
+++ b/apps/web/components/job-card.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { JobCard } from './job-card'
+
+const meta: Meta<typeof JobCard> = {
+  title: 'Home/JobCard',
+  component: JobCard,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div className="w-[360px]">
+        <Story />
+      </div>
+    ),
+  ],
+}
+export default meta
+type Story = StoryObj<typeof JobCard>
+
+const base = {
+  id: 'viralizeplus',
+  orgName: 'ViralizePlus',
+  orgDescription: 'Sua comunidade de desenvolvimento open source.',
+  orgLink: 'https://www.viralizeplus.com.br/',
+  altImage: 'V+',
+  title: 'Site Reliability Engineer',
+  location: 'Remoto',
+  date: 'Dez 2024 — Atual',
+  atribuitions: [
+    'Reestruturação das entregas com GitHub Actions, acelerando releases em ~60%.',
+    'Eficiência na AWS com economia de ~40% na fatura mensal.',
+    'Monitoramento com Grafana e Prometheus para visibilidade 24/7.',
+  ],
+  current: true,
+  tags: ['Remoto'],
+}
+
+export const Atual: Story = { args: base }
+export const Passado: Story = {
+  args: { ...base, current: false, date: 'Dez 2023 — Out 2024', tags: [] },
+}

--- a/apps/web/components/job-card.tsx
+++ b/apps/web/components/job-card.tsx
@@ -1,5 +1,4 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -14,61 +13,104 @@ import { Carreira } from '@/mocks/carreira'
 import Link from 'next/link'
 
 export function JobCard(props: Carreira) {
+  const logo = (
+    <Avatar className="bg-accent-soft size-10 shrink-0 rounded-md">
+      {props.image && (
+        <AvatarImage src={props.image} alt={props.orgName + ' Logo'} />
+      )}
+      <AvatarFallback className="bg-accent-soft text-primary rounded-md text-xs font-bold">
+        {props.altImage}
+      </AvatarFallback>
+    </Avatar>
+  )
+
   return (
     <Dialog>
-      <DialogTrigger asChild className="flex">
-        <Button
-          variant="outline"
-          className="flex h-fit w-full cursor-pointer items-start gap-5 rounded-3xl p-4"
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="group bg-card border-border hover:bg-accent flex w-full cursor-pointer flex-col gap-3 rounded-lg border p-5 text-left transition-colors"
         >
-          <Avatar className="flex h-10 w-10 shrink-0 rounded-xl">
-            {props.image && (
-              <AvatarImage src={props.image} alt={props.orgName + ' Logo'} />
-            )}
-            <AvatarFallback className="rounded-xl">
-              {props.altImage}
-            </AvatarFallback>
-          </Avatar>
-          <div className="flex w-full flex-col justify-center gap-2">
-            <section className="flex flex-col items-start justify-center gap-4">
-              <section className="flex w-full items-center justify-between">
-                <Badge>{props.orgName}</Badge>
-                <time className="text-muted-foreground text-sm">
-                  {props.date}
-                </time>
-              </section>
-              <p className="text-base">{props.title}</p>
-              <p className="text-muted-foreground">{props.location}</p>
-            </section>
+          <div className="flex items-center gap-3">
+            {logo}
+            <div className="flex flex-col">
+              <span className="leading-tight font-semibold">
+                {props.orgName}
+              </span>
+              <span className="text-muted-foreground font-mono text-xs">
+                {props.date}
+              </span>
+            </div>
           </div>
-        </Button>
+          <p className="text-sm">{props.title}</p>
+          <div className="flex flex-wrap items-center gap-2">
+            {props.current ? (
+              <span className="border-border inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs">
+                <span className="bg-ok size-1.5 rounded-full" aria-hidden />
+                Atual
+              </span>
+            ) : null}
+            {props.tags.map((tag) => (
+              <span
+                key={tag}
+                className="border-border rounded-full border px-2.5 py-0.5 text-xs"
+              >
+                {tag}
+              </span>
+            ))}
+            <span className="text-primary ml-auto font-mono text-xs">
+              detalhes →
+            </span>
+          </div>
+        </button>
       </DialogTrigger>
+
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{props.orgName}</DialogTitle>
-          <DialogDescription>{props.orgDescription}</DialogDescription>
+          <div className="flex items-start gap-4">
+            {logo}
+            <div className="flex flex-col gap-1">
+              <DialogTitle className="text-xl">{props.orgName}</DialogTitle>
+              <p className="text-muted-foreground font-mono text-xs">
+                {props.title} · {props.date}
+              </p>
+            </div>
+          </div>
+          <DialogDescription className="text-primary pt-2 text-base">
+            {props.orgDescription}
+          </DialogDescription>
         </DialogHeader>
-        <section>
-          <h4>Atribuições:</h4>
-          <ul className="list-inside list-disc">
-            {props.atribuitions.map((atribuicao: string) => (
-              <li key={atribuicao}>{atribuicao}</li>
+
+        <div className="flex flex-col gap-3">
+          <p className="text-muted-foreground font-mono text-xs tracking-[0.2em] uppercase">
+            Atribuições
+          </p>
+          <ul className="flex flex-col gap-3">
+            {props.atribuitions.map((atribuicao) => (
+              <li key={atribuicao} className="flex gap-3 text-sm">
+                <span
+                  className="bg-primary mt-1.5 size-1.5 shrink-0 rounded-[2px]"
+                  aria-hidden
+                />
+                <span>{atribuicao}</span>
+              </li>
             ))}
           </ul>
-        </section>
-        <DialogFooter>
-          {props.orgLink.trim() ? (
-            <Button asChild>
+        </div>
+
+        {props.orgLink.trim() ? (
+          <DialogFooter>
+            <Button asChild className="w-full">
               <Link
                 href={props.orgLink}
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                Saiba mais sobre {props.orgName.toLowerCase()}
+                Saiba mais sobre {props.orgName}
               </Link>
             </Button>
-          ) : null}
-        </DialogFooter>
+          </DialogFooter>
+        ) : null}
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/components/profile-social-strip.tsx
+++ b/apps/web/components/profile-social-strip.tsx
@@ -1,13 +1,13 @@
-import { EmailContactDialog } from '@/components/email-contact-dialog'
 import { getVisitCardFaIcon } from '@/lib/visit-card-fontawesome'
-import { cn } from '@/lib/utils'
 import type { Social } from '@/mocks/social'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Image from 'next/image'
 import Link from 'next/link'
 
+const CONTACT_EMAIL = 'pilutechinformatica@gmail.com'
+
 const squircleClass =
-  'inline-flex size-12 shrink-0 items-center justify-center rounded-2xl border border-border bg-card text-card-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+  'inline-flex size-12 shrink-0 items-center justify-center rounded-xl border border-border bg-card text-card-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
 
 function StripGlyph({ social }: { social: Social }) {
   if (social.iconMode === 'image' && social.image?.trim()) {
@@ -69,9 +69,10 @@ export function ProfileSocialStrip({ socials }: ProfileSocialStripProps) {
           <StripGlyph social={social} />
         </Link>
       ))}
-      <EmailContactDialog
-        triggerClassName={cn(squircleClass, 'cursor-pointer')}
-        triggerAriaLabel="Enviar mensagem por email"
+      <Link
+        href={`mailto:${CONTACT_EMAIL}`}
+        className={squircleClass}
+        aria-label="Enviar email"
       >
         {emailIcon ? (
           <FontAwesomeIcon
@@ -80,7 +81,7 @@ export function ProfileSocialStrip({ socials }: ProfileSocialStripProps) {
             aria-hidden
           />
         ) : null}
-      </EmailContactDialog>
+      </Link>
     </nav>
   )
 }

--- a/apps/web/components/project-card.stories.tsx
+++ b/apps/web/components/project-card.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { ProjectCard } from './project-card'
+
+const meta: Meta<typeof ProjectCard> = {
+  title: 'Home/ProjectCard',
+  component: ProjectCard,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+}
+export default meta
+type Story = StoryObj<typeof ProjectCard>
+
+const base = {
+  id: 'live-prs',
+  projectName: 'Live PRs',
+  subtitle: 'agregador de pull requests',
+  projectLogo: '/pr-live-dark.svg',
+  image: undefined,
+  description:
+    'Agrega os pull requests em que sua revisão foi solicitada, por repositório ou organização. Reúne tudo em cards com estado do PR, checks de CI e assignees.',
+  tags: ['React', 'Next', 'Go', 'Tailwind', 'Docker', 'AWS', 'Grafana'],
+  deployLink: 'https://example.com',
+  repoLink: 'https://github.com/example',
+  altImage: 'LPR',
+}
+
+export const Default: Story = { args: base }
+export const SemSubtitulo: Story = {
+  args: { ...base, subtitle: '', repoLink: '' },
+}

--- a/apps/web/components/project-card.tsx
+++ b/apps/web/components/project-card.tsx
@@ -1,10 +1,13 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { Project } from '@/mocks/projects'
-import Image from 'next/image'
+import {
+  faArrowUpRightFromSquare,
+  faCode,
+} from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
 
 type ProjectCardProps = Project & {
@@ -17,85 +20,74 @@ export function ProjectCard(props: ProjectCardProps) {
   return (
     <Card
       className={cn(
-        'flex h-fit flex-col justify-between gap-4 rounded-3xl p-5 xl:min-h-[454px] xl:w-80 xl:flex-col',
+        'bg-card border-border flex flex-col gap-5 rounded-lg p-6',
         className,
       )}
     >
-      <section className="flex flex-col justify-center gap-4">
-        <Avatar className="mb-2 flex h-11 w-11 shrink-0 rounded-xl">
+      <div className="flex items-center gap-4">
+        <Avatar className="bg-accent-soft size-12 shrink-0 rounded-lg">
           {project.image && (
             <AvatarImage
               src={project.projectLogo}
               alt={project.projectName + ' Logo'}
             />
           )}
-          <AvatarFallback className="rounded-xl">
+          <AvatarFallback className="bg-accent-soft text-primary rounded-lg font-bold">
             {project.altImage}
           </AvatarFallback>
         </Avatar>
-        <h3 className="text-lg font-bold">{project.projectName}</h3>
-        <p
-          className="text-muted-foreground line-clamp-6 max-h-48"
-          title={project.description}
-        >
-          {project.description}
-        </p>
-
-        <section className="flex flex-wrap items-center gap-4">
-          {project.tags.map((tag: string) => (
-            <Badge key={tag}>{tag}</Badge>
-          ))}
-        </section>
-        <section className="flex items-center gap-4">
-          {project.deployLink ? (
-            <Button asChild variant="default">
-              <Link
-                href={project.deployLink}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Demo
-              </Link>
-            </Button>
-          ) : (
-            <Button
-              disabled
-              variant="destructive"
-              className="cursor-not-allowed"
-            >
-              Demo
-            </Button>
-          )}
-          {project.repoLink ? (
-            <Button asChild variant="secondary">
-              <Link
-                href={project.repoLink}
-                rel="noopener noreferrer nofollow"
-                target="_blank"
-              >
-                Code
-              </Link>
-            </Button>
-          ) : (
-            <Button variant="secondary" disabled>
-              Code
-            </Button>
-          )}
-        </section>
-      </section>
-      {project.image ? (
-        <div className="relative mx-auto flex h-fit w-72 max-w-full shrink-0 overflow-hidden rounded-lg border transition-all hover:-translate-y-2">
-          <Image
-            alt=""
-            loading="lazy"
-            width={288}
-            height={144}
-            src={project.image}
-            className="w-full object-cover object-center"
-            style={{ width: '100%', height: 'auto' }}
-          />
+        <div className="flex flex-col">
+          <h3 className="text-xl font-bold">{project.projectName}</h3>
+          {project.subtitle ? (
+            <p className="text-muted-foreground text-sm">{project.subtitle}</p>
+          ) : null}
         </div>
-      ) : null}
+      </div>
+
+      <p className="text-muted-foreground" title={project.description}>
+        {project.description}
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        {project.tags.map((tag) => (
+          <span
+            key={tag}
+            className="border-border rounded-full border px-2.5 py-0.5 font-mono text-xs"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        {project.deployLink ? (
+          <Button asChild>
+            <Link
+              href={project.deployLink}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <FontAwesomeIcon
+                icon={faArrowUpRightFromSquare}
+                className="size-3.5"
+              />
+              Demo
+            </Link>
+          </Button>
+        ) : null}
+        {project.repoLink ? (
+          <Button asChild variant="outline">
+            <Link
+              href={project.repoLink}
+              rel="noopener noreferrer nofollow"
+              target="_blank"
+            >
+              <FontAwesomeIcon icon={faCode} className="size-3.5" />
+              Código
+            </Link>
+          </Button>
+        ) : null}
+      </div>
     </Card>
   )
 }

--- a/apps/web/components/section-header.stories.tsx
+++ b/apps/web/components/section-header.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { SectionHeader } from './section-header'
+
+const meta: Meta<typeof SectionHeader> = {
+  title: 'Home/SectionHeader',
+  component: SectionHeader,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+}
+export default meta
+type Story = StoryObj<typeof SectionHeader>
+
+export const Carreira: Story = { args: { label: 'Carreira', count: 5 } }
+export const Projetos: Story = { args: { label: 'Projetos', count: 1 } }
+export const SemContador: Story = { args: { label: 'Artigos' } }

--- a/apps/web/components/section-header.tsx
+++ b/apps/web/components/section-header.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/lib/utils'
+
+type SectionHeaderProps = {
+  label: string
+  count?: number | string
+  id?: string
+  className?: string
+}
+
+function padCount(count: number | string | undefined) {
+  if (count === undefined) return undefined
+  const n = typeof count === 'number' ? count : Number(count)
+  return Number.isFinite(n) ? String(n).padStart(2, '0') : String(count)
+}
+
+export function SectionHeader({
+  label,
+  count,
+  id,
+  className,
+}: SectionHeaderProps) {
+  const padded = padCount(count)
+  return (
+    <div className={cn('flex items-center gap-3', className)}>
+      <h2
+        id={id}
+        className="text-muted-foreground font-mono text-xs font-semibold tracking-[0.2em] uppercase"
+      >
+        {label}
+      </h2>
+      {padded !== undefined ? (
+        <span className="text-muted-foreground font-mono text-xs">
+          {padded}
+        </span>
+      ) : null}
+      <span className="bg-border h-px flex-1" aria-hidden />
+    </div>
+  )
+}

--- a/apps/web/content/carreiras/aride/index.yaml
+++ b/apps/web/content/carreiras/aride/index.yaml
@@ -18,3 +18,6 @@ atribuitions:
   - Configuração de ambiente
   - Criação de Páginas responsivas(Styled Components)
   - Consumo de APIs(Axios)
+current: true
+tags:
+  - Remoto

--- a/apps/web/content/carreiras/dev-hatt/index.yaml
+++ b/apps/web/content/carreiras/dev-hatt/index.yaml
@@ -17,3 +17,6 @@ atribuitions:
   - >-
     Primeiros alertas de saúde do sistema, dando visibilidade proativa de
     performance ao time de desenvolvimento
+current: false
+tags:
+  - Remoto

--- a/apps/web/content/carreiras/redeconfia/index.yaml
+++ b/apps/web/content/carreiras/redeconfia/index.yaml
@@ -15,3 +15,6 @@ atribuitions:
   - >-
     Módulos padronizados para criação ágil de novos recursos, mantendo padrões
     de segurança e disponibilidade em expansões
+current: false
+tags:
+  - Remoto

--- a/apps/web/content/carreiras/seven-consulting/index.yaml
+++ b/apps/web/content/carreiras/seven-consulting/index.yaml
@@ -10,3 +10,6 @@ date: Dez, 2025
 atribuitions:
   - Estratégia de proteção na AWS para continuidade mesmo em falhas regionais críticas
   - Replicação automática de dados e servidores para recuperação rápida e suporte a alta demanda sem interrupções perceptíveis aos clientes
+current: false
+tags:
+  - Remoto

--- a/apps/web/content/carreiras/viralizeplus/index.yaml
+++ b/apps/web/content/carreiras/viralizeplus/index.yaml
@@ -18,3 +18,6 @@ atribuitions:
   - >-
     Sistema de monitoramento com Grafana para visibilidade 24/7 da saúde da
     aplicação, reduzindo o tempo de resolução de incidentes
+current: true
+tags:
+  - Remoto

--- a/apps/web/content/projects/live-prs/index.yaml
+++ b/apps/web/content/projects/live-prs/index.yaml
@@ -1,6 +1,7 @@
 projectSlug: live-prs
 order: 0
 projectName: Live PRs
+subtitle: agregador de pull requests
 projectLogo: /pr-live-dark.svg
 description: >-
   Live PRs é um agregador de pull request onde foi solicitada a sua

--- a/apps/web/content/site/profile/index.yaml
+++ b/apps/web/content/site/profile/index.yaml
@@ -11,3 +11,10 @@ bio: >-
   transformar operações manuais em processos automatizados e seguros, utilizando
   ferramentas de mercado para monitorar a saúde das aplicações em tempo real e
   antecipar falhas antes que afetem o usuário final.
+availabilityOpen: true
+availabilityLabel: Disponível para oportunidades
+location: Brasil · Remoto
+disciplines:
+  - SRE
+  - DevOps
+  - Cloud

--- a/apps/web/keystatic.config.ts
+++ b/apps/web/keystatic.config.ts
@@ -74,6 +74,22 @@ export default config({
             { label: 'Cinza claro', value: '#94a3b8' },
           ],
         }),
+        availabilityOpen: fields.checkbox({
+          label: 'Disponível para oportunidades',
+          defaultValue: true,
+        }),
+        availabilityLabel: fields.text({
+          label: 'Texto de disponibilidade',
+          defaultValue: 'Disponível para oportunidades',
+        }),
+        location: fields.text({
+          label: 'Localização (meta)',
+          description: 'Ex.: Brasil · Remoto',
+          defaultValue: 'Brasil · Remoto',
+        }),
+        disciplines: fields.array(fields.text({ label: 'Disciplina' }), {
+          label: 'Disciplinas',
+        }),
         bio: fields.text({
           label: 'Biografia',
           multiline: true,
@@ -216,6 +232,10 @@ export default config({
         atribuitions: fields.array(fields.text({ label: 'Atribuição' }), {
           label: 'Atribuições',
         }),
+        current: fields.checkbox({ label: 'Cargo atual', defaultValue: false }),
+        tags: fields.array(fields.text({ label: 'Tag' }), {
+          label: 'Tags (ex.: Remoto)',
+        }),
       },
     }),
     projects: collection({
@@ -227,6 +247,11 @@ export default config({
         projectSlug: fields.slug({ name: { label: 'Slug do projeto' } }),
         order: fields.integer({ label: 'Ordem (menor primeiro)' }),
         projectName: fields.text({ label: 'Nome' }),
+        subtitle: fields.text({
+          label: 'Subtítulo',
+          description: 'Ex.: agregador de pull requests',
+          defaultValue: '',
+        }),
         projectLogo: fields.text({
           label: 'Logo (path ou URL)',
         }),

--- a/apps/web/lib/site-content.ts
+++ b/apps/web/lib/site-content.ts
@@ -36,6 +36,10 @@ export type SiteProfileContent = {
   /** Cor do nome da empresa (hex), ex. #4a65fc */
   companyLinkColor: string
   bio: string
+  availabilityOpen: boolean
+  availabilityLabel: string
+  location: string
+  disciplines: string[]
 }
 
 export type VisitCardLinkType = 'manual' | 'latestDevArticle' | 'emailContact'
@@ -90,6 +94,11 @@ export async function getSiteProfile(): Promise<SiteProfileContent | null> {
     companyLink: entry.companyLink,
     companyLinkColor: normalizeHexColor(entry.companyLinkColor, '#4a65fc'),
     bio: entry.bio,
+    availabilityOpen: entry.availabilityOpen ?? true,
+    availabilityLabel:
+      (entry.availabilityLabel ?? '').trim() || 'Disponível para oportunidades',
+    location: (entry.location ?? '').trim(),
+    disciplines: [...(entry.disciplines ?? [])].filter((d) => d.trim()),
   }
 }
 
@@ -178,6 +187,8 @@ export async function getCarreiras(): Promise<Carreira[]> {
       location: entry.location,
       date: entry.date,
       atribuitions: [...entry.atribuitions],
+      current: entry.current ?? false,
+      tags: [...(entry.tags ?? [])].filter((t) => t.trim()),
       order: entry.order ?? 0,
     }
   })
@@ -193,6 +204,8 @@ export async function getCarreiras(): Promise<Carreira[]> {
       location: row.location,
       date: row.date,
       atribuitions: row.atribuitions,
+      current: row.current,
+      tags: row.tags,
     }),
   )
 }
@@ -206,6 +219,7 @@ export async function getProjects(): Promise<Project[]> {
     return {
       id: slug,
       projectName: entry.projectName,
+      subtitle: (entry.subtitle ?? '').trim(),
       projectLogo: entry.projectLogo,
       description: entry.description,
       tags: [...entry.tags],
@@ -220,6 +234,7 @@ export async function getProjects(): Promise<Project[]> {
     (row): Project => ({
       id: row.id,
       projectName: row.projectName,
+      subtitle: row.subtitle,
       projectLogo: row.projectLogo,
       description: row.description,
       tags: row.tags,

--- a/apps/web/mocks/carreira.ts
+++ b/apps/web/mocks/carreira.ts
@@ -9,4 +9,6 @@ export type Carreira = {
   location: string
   date: string
   atribuitions: string[]
+  current: boolean
+  tags: string[]
 }

--- a/apps/web/mocks/projects.ts
+++ b/apps/web/mocks/projects.ts
@@ -1,6 +1,7 @@
 export type Project = {
   id: string
   projectName: string
+  subtitle: string
   projectLogo: string
   description: string
   tags: string[]

--- a/docs/superpowers/plans/2026-06-02-design-system-v2-foundation.md
+++ b/docs/superpowers/plans/2026-06-02-design-system-v2-foundation.md
@@ -1,0 +1,441 @@
+# Design System V2 "Cloud (cyan)" Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrar a base visual do app para o Design System V2 "Cloud (cyan)" trocando apenas os valores dos tokens de tema e as fontes, sem reescrever páginas.
+
+**Architecture:** Mapeia os tokens do V2 sobre as variáveis shadcn já existentes em `app/globals.css` (V2 `--accent` ciano → shadcn `--primary`), adiciona tokens semânticos novos (`--ok/--warn/--win`) e troca as fontes via `next/font`. Componentes shadcn herdam o look automaticamente.
+
+**Tech Stack:** Next.js 16 (App Router), Tailwind CSS 4 (`@theme`), shadcn/ui, next-themes (já configurado, dark default), next/font/google, Storybook 10 (`@storybook/nextjs`).
+
+**Spec:** `docs/superpowers/specs/2026-06-02-design-system-v2-foundation-design.md`
+
+**Nota sobre verificação:** esta fundação é CSS + config (não há lógica nova). Logo **não há testes Jest** — a verificação é `lint` + `tsc --noEmit` + `build` (gates) e uma **story "Design Tokens"** no Storybook como superfície visual. Os E2E existentes não devem quebrar (nenhuma mudança de DOM/estrutura).
+
+---
+
+## File Structure
+
+| Arquivo                                         | Responsabilidade                                   | Ação                                                                                            |
+| ----------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `apps/web/app/layout.tsx`                       | Root layout — carrega fontes globais               | Modificar: trocar Inter por Plus Jakarta Sans + JetBrains Mono                                  |
+| `apps/web/app/globals.css`                      | Tema (tokens shadcn + `@theme` Tailwind)           | Modificar: `@theme` (fontes, semânticos, raio, sombra), `:root` (light), `.dark` (dark), `body` |
+| `apps/web/components/design-tokens.stories.tsx` | Story de verificação visual da paleta/fontes/forma | Criar                                                                                           |
+
+Tudo num único arquivo de tema (`globals.css`) — é o padrão do projeto e a fonte única de tokens. Sem split.
+
+---
+
+## Task 1: Trocar fontes (Inter → Plus Jakarta Sans + JetBrains Mono)
+
+**Files:**
+
+- Modify: `apps/web/app/layout.tsx:2,6,92,93`
+- Modify: `apps/web/app/globals.css` (bloco `@theme` + regra `body`)
+
+- [ ] **Step 1: Trocar import e instâncias de fonte no layout**
+
+Em `apps/web/app/layout.tsx`, substituir a linha 2 (`import { Inter } ...`) e a linha 6 (`const inter = ...`):
+
+```ts
+import { Plus_Jakarta_Sans, JetBrains_Mono } from 'next/font/google'
+
+const sans = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-plus-jakarta',
+  display: 'swap',
+})
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains',
+  display: 'swap',
+})
+```
+
+- [ ] **Step 2: Aplicar as variáveis de fonte no `<html>` e limpar o `<body>`**
+
+Em `apps/web/app/layout.tsx`, trocar o bloco de retorno (linhas 91-97):
+
+```tsx
+return (
+  <html
+    lang="pt-BR"
+    className={`${sans.variable} ${mono.variable}`}
+    suppressHydrationWarning
+  >
+    <body suppressHydrationWarning>{children}</body>
+  </html>
+)
+```
+
+(remove o `className={inter.className}` do `<body>`)
+
+- [ ] **Step 3: Mapear as fontes no `@theme` e aplicar `font-sans` no `body`**
+
+Em `apps/web/app/globals.css`, dentro do bloco `@theme { ... }` (logo após o bloco de `--color-*`, antes dos `--radius-*`), adicionar:
+
+```css
+--font-sans: var(--font-plus-jakarta), ui-sans-serif, system-ui, sans-serif;
+--font-mono: var(--font-jetbrains), ui-monospace, monospace;
+```
+
+E na regra `body` do `@layer base` (hoje `body { @apply bg-background text-foreground; }`), adicionar `font-sans`:
+
+```css
+body {
+  @apply bg-background text-foreground font-sans;
+}
+```
+
+- [ ] **Step 4: Verificar tipos e build**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit`
+Expected: PASS (sem erros).
+
+Run (na raiz): `pnpm --filter @piluvitu/web build`
+Expected: build conclui; nenhuma referência a `inter` restante (a remoção da var não deve deixar import órfão — confirmar que `Inter` não é mais importado).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/layout.tsx apps/web/app/globals.css
+git commit -m "feat(web): swap fonts to Plus Jakarta Sans + JetBrains Mono (DS V2)"
+```
+
+---
+
+## Task 2: Adicionar mapeamentos `@theme` (semânticos, marca translúcida, raio-pill, sombra)
+
+**Files:**
+
+- Modify: `apps/web/app/globals.css` (bloco `@theme`)
+
+- [ ] **Step 1: Adicionar os novos tokens no `@theme`**
+
+Em `apps/web/app/globals.css`, dentro do `@theme`, logo após as linhas de `--color-success` / `--color-success-foreground`, adicionar:
+
+```css
+--color-ok: hsl(var(--ok));
+--color-ok-foreground: hsl(var(--ok-foreground));
+--color-warn: hsl(var(--warn));
+--color-warn-foreground: hsl(var(--warn-foreground));
+--color-win: hsl(var(--win));
+--color-win-foreground: hsl(var(--win-foreground));
+
+--color-accent-soft: rgb(56 189 248 / 0.13);
+--color-accent-line: rgb(56 189 248 / 0.32);
+
+--radius-pill: 999px;
+--shadow-ds: 0 18px 40px rgb(0 0 0 / 0.45);
+```
+
+> Isso cria os utilitários `text-ok` / `bg-warn` / `text-win` / `bg-accent-soft` / `border-accent-line` / `rounded-pill` / `shadow-ds`. Os valores `hsl(var(--ok))` etc. só resolvem depois que `--ok/--warn/--win` forem definidos nos blocos `:root`/`.dark` (Tasks 3 e 4) — sem quebra de build no meio, pois esses utilitários ainda não são usados.
+
+- [ ] **Step 2: Build**
+
+Run (na raiz): `pnpm --filter @piluvitu/web build`
+Expected: build conclui sem erro.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/globals.css
+git commit -m "feat(web): add DS V2 @theme tokens (ok/warn/win, accent-soft/line, pill, shadow)"
+```
+
+---
+
+## Task 3: Reescrever a paleta dark (`.dark`) com o V2 "Cloud (cyan)"
+
+**Files:**
+
+- Modify: `apps/web/app/globals.css` (bloco `.dark`, hoje linhas ~135-157)
+
+- [ ] **Step 1: Substituir o conteúdo do bloco `.dark`**
+
+Em `apps/web/app/globals.css`, substituir todo o corpo do bloco `.dark { ... }` por:
+
+```css
+.dark {
+  --background: 220 33% 5%;
+  --foreground: 215 33% 93%;
+  --card: 222 36% 9%;
+  --card-foreground: 215 33% 93%;
+  --popover: 222 36% 9%;
+  --popover-foreground: 215 33% 93%;
+  --primary: 198 93% 60%;
+  --primary-foreground: 200 75% 6%;
+  --secondary: 221 35% 12%;
+  --secondary-foreground: 215 33% 93%;
+  --muted: 221 35% 12%;
+  --muted-foreground: 216 17% 64%;
+  --accent: 217 32% 14%;
+  --accent-foreground: 215 33% 93%;
+  --destructive: 0 91% 71%;
+  --destructive-foreground: 200 75% 6%;
+  --border: 205 40% 18%;
+  --input: 205 40% 18%;
+  --ring: 198 93% 60%;
+  --success: 158 64% 52%;
+  --success-foreground: 200 75% 6%;
+  --ok: 158 64% 52%;
+  --ok-foreground: 200 75% 6%;
+  --warn: 43 96% 56%;
+  --warn-foreground: 200 75% 6%;
+  --win: 255 92% 76%;
+  --win-foreground: 200 75% 6%;
+}
+```
+
+- [ ] **Step 2: Verificar visualmente no Storybook (dark)**
+
+Run (na raiz): `pnpm --filter @piluvitu/web storybook`
+Expected: Storybook abre; componentes shadcn (Button/Card/Badge) aparecem com fundo dark azulado e acento ciano. (Confirmação final na story de tokens, Task 5.)
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm --filter @piluvitu/web build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/globals.css
+git commit -m "feat(web): apply DS V2 dark palette (Cloud cyan) to .dark theme"
+```
+
+---
+
+## Task 4: Reescrever a paleta light (`:root`) derivada + `--radius` 18px
+
+**Files:**
+
+- Modify: `apps/web/app/globals.css` (bloco `:root`, hoje linhas ~110-133)
+
+- [ ] **Step 1: Substituir o conteúdo do bloco `:root`**
+
+Em `apps/web/app/globals.css`, substituir todo o corpo do bloco `:root { ... }` (o bloco de tema dentro do `@layer base`, que termina com `--radius: 0.75rem;`) por:
+
+```css
+:root {
+  --background: 220 50% 98%;
+  --foreground: 222 36% 9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222 36% 9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222 36% 9%;
+  --primary: 198 93% 60%;
+  --primary-foreground: 200 75% 6%;
+  --secondary: 216 42% 95%;
+  --secondary-foreground: 222 36% 9%;
+  --muted: 216 42% 95%;
+  --muted-foreground: 215 18% 35%;
+  --accent: 216 43% 93%;
+  --accent-foreground: 222 36% 9%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 216 30% 88%;
+  --input: 216 30% 88%;
+  --ring: 198 93% 60%;
+  --success: 158 64% 40%;
+  --success-foreground: 0 0% 100%;
+  --ok: 158 64% 40%;
+  --ok-foreground: 0 0% 100%;
+  --warn: 38 92% 45%;
+  --warn-foreground: 0 0% 100%;
+  --win: 255 60% 60%;
+  --win-foreground: 0 0% 100%;
+  --radius: 1.125rem;
+}
+```
+
+> `--radius: 1.125rem` (18px) é theme-independent (só no `:root`); a escala shadcn vira lg=18 / md=16 / sm=14 px. `--ring`/`--primary` ciano valem nos dois temas.
+
+- [ ] **Step 2: Verificar visualmente no Storybook (light via toggle)**
+
+Run (na raiz): `pnpm --filter @piluvitu/web storybook`
+Expected: alternando para light, superfícies ficam claras, texto escuro, acento ciano preservado; sem contraste grosseiramente quebrado.
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm --filter @piluvitu/web build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/globals.css
+git commit -m "feat(web): derive DS V2 light palette + soften radius to 18px"
+```
+
+---
+
+## Task 5: Story "Design Tokens" (verificação visual)
+
+**Files:**
+
+- Create: `apps/web/components/design-tokens.stories.tsx`
+
+- [ ] **Step 1: Criar a story**
+
+Criar `apps/web/components/design-tokens.stories.tsx` com o conteúdo completo:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/nextjs'
+
+const meta: Meta = {
+  title: 'Design System/Tokens',
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+}
+export default meta
+type Story = StoryObj
+
+function Swatch({ label, className }: { label: string; className: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div
+        className={`border-border h-16 w-full rounded-lg border ${className}`}
+      />
+      <span className="text-muted-foreground font-mono text-xs">{label}</span>
+    </div>
+  )
+}
+
+const colors: Array<{ label: string; className: string }> = [
+  { label: 'background', className: 'bg-background' },
+  { label: 'foreground', className: 'bg-foreground' },
+  { label: 'card', className: 'bg-card' },
+  { label: 'secondary', className: 'bg-secondary' },
+  { label: 'muted', className: 'bg-muted' },
+  { label: 'accent (hover)', className: 'bg-accent' },
+  { label: 'primary', className: 'bg-primary' },
+  { label: 'destructive', className: 'bg-destructive' },
+  { label: 'ok', className: 'bg-ok' },
+  { label: 'warn', className: 'bg-warn' },
+  { label: 'win', className: 'bg-win' },
+  { label: 'accent-soft', className: 'bg-accent-soft' },
+]
+
+export const Colors: Story = {
+  render: () => (
+    <div className="bg-background p-8">
+      <h2 className="text-foreground mb-4 text-lg font-semibold">Cores</h2>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {colors.map((c) => (
+          <Swatch key={c.label} label={c.label} className={c.className} />
+        ))}
+      </div>
+    </div>
+  ),
+}
+
+export const Typography: Story = {
+  render: () => (
+    <div className="bg-background text-foreground space-y-4 p-8">
+      <p className="font-sans text-3xl font-bold">
+        Plus Jakarta Sans — Display
+      </p>
+      <p className="font-sans text-base">
+        Plus Jakarta Sans — corpo de leitura confortável.
+      </p>
+      <p className="text-muted-foreground font-mono text-sm">
+        JetBrains Mono — labels · metadados · 2026-06-02
+      </p>
+    </div>
+  ),
+}
+
+export const ShapeAndShadow: Story = {
+  render: () => (
+    <div className="bg-background flex flex-wrap items-end gap-6 p-8">
+      <div className="shadow-ds bg-card text-card-foreground flex h-32 w-48 items-center justify-center rounded-lg">
+        rounded-lg (18px) + shadow-ds
+      </div>
+      <span className="rounded-pill bg-primary text-primary-foreground px-4 py-1 text-sm">
+        rounded-pill
+      </span>
+    </div>
+  ),
+}
+```
+
+- [ ] **Step 2: Lint + tipos**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit`
+Expected: PASS.
+
+Run (na raiz): `pnpm lint`
+Expected: PASS (sem erros ESLint na story nova).
+
+- [ ] **Step 3: Conferir no Storybook**
+
+Run: `pnpm --filter @piluvitu/web storybook`
+Expected: aparece "Design System / Tokens" com Colors, Typography, ShapeAndShadow; alternar dark/light reflete as duas paletas.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/components/design-tokens.stories.tsx
+git commit -m "test(web): add Design Tokens story as DS V2 visual verification surface"
+```
+
+---
+
+## Task 6: Passada final de verificação + atualizar CLAUDE.md
+
+**Files:**
+
+- Modify: `apps/web/CLAUDE.md` ou `CLAUDE.md` raiz (seção Theme/Tech Stack) — registrar o DS V2
+
+- [ ] **Step 1: Rodar a sequência completa de qualidade (regras do projeto)**
+
+Run, em ordem:
+
+1. `pnpm prettier:fix`
+2. `pnpm lint`
+3. `pnpm exec tsc --noEmit` (em `apps/web/`)
+4. `pnpm --filter @piluvitu/web build`
+
+Expected: todos verdes.
+
+- [ ] **Step 2: Conferir critérios de aceite da spec (§11)**
+
+Verificar manualmente no Storybook/dev:
+
+- App dark "Cloud (cyan)" por padrão; acento ciano `#38bdf8` em Button/links/foco.
+- Toggle alterna para light derivado sem contraste grosseiro.
+- Corpo em Plus Jakarta Sans; `font-mono` em JetBrains Mono.
+- `text-ok/bg-warn/text-win` funcionam; `text-success` antigo segue válido.
+- Cards com raio 18px + `shadow-ds`.
+
+- [ ] **Step 3: Atualizar o CLAUDE.md (regra do projeto: tecnologia nova/fluxo alterado)**
+
+Na seção **### Theme** do `CLAUDE.md` raiz, acrescentar parágrafo registrando: tema agora é o **Design System V2 "Cloud (cyan)"** (dark default via next-themes), tokens shadcn mapeados do V2, fontes Plus Jakarta Sans + JetBrains Mono, semânticos `--ok/--warn/--win` (votação), `--radius-pill`/`--shadow-ds`, e link para a spec `docs/superpowers/specs/2026-06-02-design-system-v2-foundation-design.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md apps/web
+git commit -m "docs: register DS V2 Cloud theme foundation in CLAUDE.md"
+```
+
+---
+
+## Self-Review (preenchido pelo autor do plano)
+
+**Spec coverage:**
+
+- §3 dark palette → Task 3 ✅
+- §3 semânticos + accent-soft/line → Task 2 (mapeamento) + Tasks 3/4 (valores) ✅
+- §4 light palette → Task 4 ✅
+- §5 fontes → Task 1 ✅
+- §6 raio/pill/shadow → Task 2 (pill/shadow) + Task 4 (--radius) ✅
+- §7 tema default → sem código (já configurado); confirmado em Tasks 3/4 Step 2 ✅
+- §8 arquivos → Tasks 1-6 cobrem layout.tsx, globals.css, story; CLAUDE.md em Task 6 ✅
+- §10 verificação → Task 6 ✅
+- §11 aceite → Task 6 Step 2 ✅
+
+**Placeholder scan:** sem TBD/TODO; todo passo de código tem o código completo. ✅
+
+**Type/consistency:** nomes de token consistentes entre `@theme` (`--color-ok` → `hsl(var(--ok))`) e blocos `:root`/`.dark` (`--ok`, `--ok-foreground`). Utilitários usados na story (`bg-ok`, `bg-warn`, `bg-win`, `bg-accent-soft`, `rounded-pill`, `shadow-ds`, `font-mono`) todos definidos no `@theme` da Task 2 + valores nas Tasks 3/4. ✅

--- a/docs/superpowers/plans/2026-06-02-home-v2-reskin.md
+++ b/docs/superpowers/plans/2026-06-02-home-v2-reskin.md
@@ -1,0 +1,1170 @@
+# Home V2 "Cloud (cyan)" Reskin — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reestilizar a home (`/`) pro Design System V2 — perfil fixo à esquerda, conteúdo "bento" rolável à direita com section-headers + cards V2 + modal de carreira — reusando os dados do Keystatic.
+
+**Architecture:** Mantém o split-scroll e o `home-bento-layout.tsx` (reestilizado no lugar). Adiciona campos editáveis ao Keystatic (perfil: status/local/disciplinas; carreira: `current`/`tags`; projeto: `subtitle`), propaga pelos readers/types, e reestiliza os componentes usando os tokens DS V2 já existentes (fundação / PR #32).
+
+**Tech Stack:** Next.js 16 (App Router, RSC), Tailwind 4, shadcn/ui (Dialog, Button, Card, Avatar, Badge), Keystatic 0.5, Font Awesome 7, Storybook 10 (`@storybook/nextjs`).
+
+**Spec:** `docs/superpowers/specs/2026-06-02-home-v2-reskin-design.md`
+
+**Verificação:** fundação visual ⇒ gates são `lint` + `tsc --noEmit` + `build` + **Storybook**. Sem migração de DB (schema Keystatic é declarativo — sem comando). Jest só onde houver lógica pura.
+
+---
+
+## File Structure
+
+| Arquivo                                                                                              | Responsabilidade            | Ação                                                                       |
+| ---------------------------------------------------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------- |
+| `keystatic.config.ts`                                                                                | Schema CMS                  | Modificar (siteProfile, carreiras, projects)                               |
+| `lib/site-content.ts`                                                                                | Readers + tipos             | Modificar (getSiteProfile/getCarreiras/getProjects + `SiteProfileContent`) |
+| `mocks/carreira.ts`, `mocks/projects.ts`                                                             | Tipos de domínio            | Modificar (`current`/`tags`, `subtitle?`)                                  |
+| `content/site/profile/index.yaml`, `content/carreiras/*/index.yaml`, `content/projects/*/index.yaml` | Conteúdo                    | Modificar (valores novos)                                                  |
+| `components/section-header.tsx` (+story)                                                             | Header de seção             | Criar                                                                      |
+| `components/home-footer.tsx` (+story)                                                                | Footer da home              | Criar                                                                      |
+| `components/home-bento-layout.tsx`                                                                   | Layout do conteúdo          | Reestilizar                                                                |
+| `components/bio.tsx`                                                                                 | Coluna de perfil            | Reestilizar                                                                |
+| `components/profile-social-strip.tsx`                                                                | Ícones sociais              | Reestilizar (email→mailto)                                                 |
+| `components/job-card.tsx` (+story)                                                                   | Card + modal carreira       | Reestilizar                                                                |
+| `components/project-card.tsx` (+story)                                                               | Card de projeto             | Reestilizar                                                                |
+| `components/article-card.tsx`, `components/article-section.tsx`                                      | Card de artigo              | Reestilizar (+ index)                                                      |
+| `app/(site)/page.tsx`                                                                                | Container + glow + fallback | Modificar                                                                  |
+
+---
+
+## Task 1: Camada de dados (Keystatic schema + tipos + readers + conteúdo)
+
+**Files:**
+
+- Modify: `apps/web/keystatic.config.ts`
+- Modify: `apps/web/lib/site-content.ts`
+- Modify: `apps/web/mocks/carreira.ts`, `apps/web/mocks/projects.ts`
+- Modify: `apps/web/content/site/profile/index.yaml`, `apps/web/content/carreiras/*/index.yaml`, `apps/web/content/projects/*/index.yaml`
+- Modify: `apps/web/app/(site)/page.tsx` (fallbackProfile)
+
+- [ ] **Step 1: Adicionar campos ao `keystatic.config.ts`**
+
+No `siteProfile.schema`, após `companyLinkColor` (antes de `bio`), adicionar:
+
+```ts
+        availabilityOpen: fields.checkbox({
+          label: 'Disponível para oportunidades',
+          defaultValue: true,
+        }),
+        availabilityLabel: fields.text({
+          label: 'Texto de disponibilidade',
+          defaultValue: 'Disponível para oportunidades',
+        }),
+        location: fields.text({
+          label: 'Localização (meta)',
+          description: 'Ex.: Brasil · Remoto',
+          defaultValue: 'Brasil · Remoto',
+        }),
+        disciplines: fields.array(fields.text({ label: 'Disciplina' }), {
+          label: 'Disciplinas',
+        }),
+```
+
+No `carreiras.schema`, após `atribuitions`, adicionar:
+
+```ts
+        current: fields.checkbox({ label: 'Cargo atual', defaultValue: false }),
+        tags: fields.array(fields.text({ label: 'Tag' }), {
+          label: 'Tags (ex.: Remoto)',
+        }),
+```
+
+No `projects.schema`, após `projectName`, adicionar:
+
+```ts
+        subtitle: fields.text({
+          label: 'Subtítulo',
+          description: 'Ex.: agregador de pull requests',
+          defaultValue: '',
+        }),
+```
+
+- [ ] **Step 2: Atualizar tipos em `mocks/`**
+
+`mocks/carreira.ts` — adicionar ao type `Carreira`:
+
+```ts
+  current: boolean
+  tags: string[]
+```
+
+`mocks/projects.ts` — adicionar ao type `Project`:
+
+```ts
+subtitle: string
+```
+
+- [ ] **Step 3: Atualizar `SiteProfileContent` + readers em `lib/site-content.ts`**
+
+No type `SiteProfileContent`, após `bio: string`, adicionar:
+
+```ts
+  availabilityOpen: boolean
+  availabilityLabel: string
+  location: string
+  disciplines: string[]
+```
+
+Em `getSiteProfile`, no objeto retornado (após `bio: entry.bio`), adicionar:
+
+```ts
+    availabilityOpen: entry.availabilityOpen ?? true,
+    availabilityLabel:
+      (entry.availabilityLabel ?? '').trim() || 'Disponível para oportunidades',
+    location: (entry.location ?? '').trim(),
+    disciplines: [...(entry.disciplines ?? [])].filter((d) => d.trim()),
+```
+
+Em `getCarreiras`, no objeto `mapped` (após `atribuitions: [...entry.atribuitions]`), adicionar `current: entry.current ?? false,` e `tags: [...(entry.tags ?? [])].filter((t) => t.trim()),`; e no objeto final tipado `(row): Carreira` adicionar `current: row.current,` e `tags: row.tags,`.
+
+Em `getProjects`, no objeto `mapped` (após `projectName: entry.projectName`), adicionar `subtitle: (entry.subtitle ?? '').trim(),`; e no objeto final `(row): Project` adicionar `subtitle: row.subtitle,`.
+
+- [ ] **Step 4: Atualizar conteúdo YAML**
+
+`content/site/profile/index.yaml` — adicionar ao final:
+
+```yaml
+availabilityOpen: true
+availabilityLabel: Disponível para oportunidades
+location: Brasil · Remoto
+disciplines:
+  - SRE
+  - DevOps
+  - Cloud
+```
+
+Cada `content/carreiras/*/index.yaml` — adicionar `current` e `tags`. Regra: `current: true` quando o `date` indica vigência (contém "Atual"/"Atualmente"), senão `false`. `tags` reflete o `location` (ex.: `- Remoto` quando `location: Remoto`). Exemplo:
+
+```yaml
+current: false
+tags:
+  - Remoto
+```
+
+Cada `content/projects/*/index.yaml` — adicionar `subtitle` (ex.: para `live-prs`: `subtitle: agregador de pull requests`; para os demais, uma frase curta ou `subtitle: ''`).
+
+- [ ] **Step 5: Atualizar `fallbackProfile` em `app/(site)/page.tsx`**
+
+No objeto `fallbackProfile`, após `bio: '...'`, adicionar:
+
+```ts
+  availabilityOpen: true,
+  availabilityLabel: 'Disponível para oportunidades',
+  location: 'Brasil · Remoto',
+  disciplines: ['SRE', 'DevOps', 'Cloud'],
+```
+
+- [ ] **Step 6: Verificar tipos + build**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit` → PASS (os readers passam a expor os novos campos; os componentes ainda não os usam).
+Run (raiz): `pnpm --filter @piluvitu/web build` → PASS.
+
+> Sem comando de migração — schema Keystatic é declarativo. Conteúdo antigo fica seguro pelos defaults nos readers.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/keystatic.config.ts apps/web/lib/site-content.ts apps/web/mocks apps/web/content apps/web/app
+git commit -m "feat(web): add Keystatic fields for home V2 (profile meta, career current/tags, project subtitle)"
+```
+
+---
+
+## Task 2: `SectionHeader` (+ story)
+
+**Files:**
+
+- Create: `apps/web/components/section-header.tsx`
+- Create: `apps/web/components/section-header.stories.tsx`
+
+- [ ] **Step 1: Criar o componente**
+
+`apps/web/components/section-header.tsx`:
+
+```tsx
+import { cn } from '@/lib/utils'
+
+type SectionHeaderProps = {
+  label: string
+  count?: number | string
+  id?: string
+  className?: string
+}
+
+function padCount(count: number | string | undefined) {
+  if (count === undefined) return undefined
+  const n = typeof count === 'number' ? count : Number(count)
+  return Number.isFinite(n) ? String(n).padStart(2, '0') : String(count)
+}
+
+export function SectionHeader({
+  label,
+  count,
+  id,
+  className,
+}: SectionHeaderProps) {
+  const padded = padCount(count)
+  return (
+    <div className={cn('flex items-center gap-3', className)}>
+      <h2
+        id={id}
+        className="text-muted-foreground font-mono text-xs font-semibold tracking-[0.2em] uppercase"
+      >
+        {label}
+      </h2>
+      {padded !== undefined ? (
+        <span className="text-muted-foreground font-mono text-xs">
+          {padded}
+        </span>
+      ) : null}
+      <span className="bg-border h-px flex-1" aria-hidden />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Criar a story**
+
+`apps/web/components/section-header.stories.tsx`:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { SectionHeader } from './section-header'
+
+const meta: Meta<typeof SectionHeader> = {
+  title: 'Home/SectionHeader',
+  component: SectionHeader,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+}
+export default meta
+type Story = StoryObj<typeof SectionHeader>
+
+export const Carreira: Story = { args: { label: 'Carreira', count: 5 } }
+export const Projetos: Story = { args: { label: 'Projetos', count: 1 } }
+export const SemContador: Story = { args: { label: 'Artigos' } }
+```
+
+- [ ] **Step 3: Verificar + commit**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit` e `pnpm lint` → PASS.
+
+```bash
+git add apps/web/components/section-header.tsx apps/web/components/section-header.stories.tsx
+git commit -m "feat(web): SectionHeader component (mono label + count + rule)"
+```
+
+---
+
+## Task 3: `HomeFooter` (+ story)
+
+**Files:**
+
+- Create: `apps/web/components/home-footer.tsx`
+- Create: `apps/web/components/home-footer.stories.tsx`
+
+- [ ] **Step 1: Criar o componente**
+
+`apps/web/components/home-footer.tsx`:
+
+```tsx
+import Link from 'next/link'
+
+type HomeFooterProps = {
+  name: string
+  year?: number
+}
+
+export function HomeFooter({
+  name,
+  year = new Date().getFullYear(),
+}: HomeFooterProps) {
+  return (
+    <footer className="text-muted-foreground border-border mt-2 flex flex-col gap-2 border-t pt-6 font-mono text-xs sm:flex-row sm:items-center sm:justify-between">
+      <span>
+        © {year} {name}
+      </span>
+      <span className="flex flex-wrap items-center gap-x-2">
+        <span>piluvitu.com.br</span>
+        <span aria-hidden>·</span>
+        <Link href="/tools" className="hover:text-foreground transition-colors">
+          /tools
+        </Link>
+        <span aria-hidden>·</span>
+        <Link
+          href="/votacao"
+          className="hover:text-foreground transition-colors"
+        >
+          /votação
+        </Link>
+        <span aria-hidden>·</span>
+        <Link
+          href="/votacao/admin"
+          className="hover:text-foreground transition-colors"
+        >
+          admin
+        </Link>
+      </span>
+    </footer>
+  )
+}
+```
+
+- [ ] **Step 2: Criar a story**
+
+`apps/web/components/home-footer.stories.tsx`:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { HomeFooter } from './home-footer'
+
+const meta: Meta<typeof HomeFooter> = {
+  title: 'Home/HomeFooter',
+  component: HomeFooter,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+}
+export default meta
+type Story = StoryObj<typeof HomeFooter>
+
+export const Default: Story = {
+  args: { name: 'Paulo Victor Torres Silva', year: 2026 },
+}
+```
+
+- [ ] **Step 3: Verificar + commit**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit` e `pnpm lint` → PASS.
+
+```bash
+git add apps/web/components/home-footer.tsx apps/web/components/home-footer.stories.tsx
+git commit -m "feat(web): HomeFooter component"
+```
+
+---
+
+## Task 4: Reestilizar `home-bento-layout.tsx`
+
+**Files:**
+
+- Modify: `apps/web/components/home-bento-layout.tsx`
+
+- [ ] **Step 1: Substituir o conteúdo do arquivo**
+
+`apps/web/components/home-bento-layout.tsx` (conteúdo completo):
+
+```tsx
+import { ArticleSection } from '@/components/article-section'
+import { HomeFooter } from '@/components/home-footer'
+import { JobCard } from '@/components/job-card'
+import { ProjectCard } from '@/components/project-card'
+import { SectionHeader } from '@/components/section-header'
+import type { ArticleCardView } from '@/lib/article-feed'
+import type { Carreira } from '@/mocks/carreira'
+import type { Project } from '@/mocks/projects'
+
+type HomeBentoLayoutProps = {
+  carreiraList: Carreira[]
+  projectList: Project[]
+  initialBlogPosts: ArticleCardView[]
+  profileName: string
+}
+
+export function HomeBentoLayout({
+  carreiraList,
+  projectList,
+  initialBlogPosts,
+  profileName,
+}: HomeBentoLayoutProps) {
+  return (
+    <div className="flex min-h-0 flex-col gap-10 xl:gap-12">
+      <section
+        aria-labelledby="carreira-heading"
+        className="flex flex-col gap-5"
+        suppressHydrationWarning
+      >
+        <SectionHeader
+          id="carreira-heading"
+          label="Carreira"
+          count={carreiraList.length}
+        />
+        <div className="grid grid-cols-1 gap-3.5 xl:grid-cols-2">
+          {carreiraList.map((carreira) => (
+            <JobCard key={carreira.id} {...carreira} />
+          ))}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="projetos-heading"
+        className="flex flex-col gap-5"
+        suppressHydrationWarning
+      >
+        <SectionHeader
+          id="projetos-heading"
+          label="Projetos"
+          count={projectList.length}
+        />
+        <div className="grid grid-cols-1 gap-6">
+          {projectList.map((project) => (
+            <ProjectCard key={project.id} {...project} />
+          ))}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="artigos-heading"
+        className="flex flex-col gap-5"
+        suppressHydrationWarning
+      >
+        <SectionHeader
+          id="artigos-heading"
+          label="Artigos"
+          count={initialBlogPosts.length}
+        />
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+          <ArticleSection initialBlogPosts={initialBlogPosts} />
+        </div>
+      </section>
+
+      <HomeFooter name={profileName} />
+    </div>
+  )
+}
+```
+
+> Nota: o contador de Artigos usa `initialBlogPosts.length` (posts do blog conhecidos no server); o feed mescla dev.to client-side. Aceitável pra v1.
+
+- [ ] **Step 2: Verificar + commit** (vai compilar só após Task 6/7 reestilizarem JobCard/ProjectCard, mas a assinatura não muda — `tsc` deve passar já)
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit` → PASS.
+
+```bash
+git add apps/web/components/home-bento-layout.tsx
+git commit -m "feat(web): restyle home bento layout with SectionHeader + footer"
+```
+
+---
+
+## Task 5: Reestilizar `bio.tsx` + `profile-social-strip.tsx`
+
+**Files:**
+
+- Modify: `apps/web/components/bio.tsx`
+- Modify: `apps/web/components/profile-social-strip.tsx`
+
+- [ ] **Step 1: Substituir `bio.tsx`**
+
+```tsx
+import Link from 'next/link'
+import { faBriefcase, faLocationDot } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import type { SiteProfileContent, VisitCardContent } from '@/lib/site-content'
+import type { Social } from '@/mocks/social'
+import { ModeToggle } from './mode-toggle'
+import { ProfileVisitCard } from './profile-visit-card'
+import { ProfileSocialStrip } from './profile-social-strip'
+import { Button } from './ui/button'
+
+type BioProps = {
+  profile: SiteProfileContent
+  socials: Social[]
+  latestDevArticleUrl: string | null
+  visitCard: VisitCardContent
+}
+
+export function Bio({
+  profile,
+  socials,
+  latestDevArticleUrl,
+  visitCard,
+}: BioProps) {
+  const companyHref = profile.companyLink.trim()
+  const hasMeta = Boolean(profile.location) || profile.disciplines.length > 0
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-start justify-between gap-4">
+        <ProfileVisitCard
+          profile={profile}
+          visitCard={visitCard}
+          latestDevArticleUrl={latestDevArticleUrl}
+        />
+        <ModeToggle />
+      </div>
+
+      {profile.availabilityOpen ? (
+        <p className="text-muted-foreground flex items-center gap-2 font-mono text-xs">
+          <span className="bg-ok size-2 rounded-full" aria-hidden />
+          {profile.availabilityLabel}
+        </p>
+      ) : null}
+
+      <h1 className="text-4xl font-bold tracking-tight xl:text-5xl">
+        {profile.displayName}
+      </h1>
+
+      <div className="flex flex-col gap-4">
+        <p>
+          <strong className="text-primary font-semibold">
+            {profile.roleHighlight}
+          </strong>
+          {profile.companyName.trim() ? (
+            <>
+              {' na '}
+              {companyHref ? (
+                <Button
+                  asChild
+                  variant="link"
+                  className="h-fit p-0"
+                  style={{ color: profile.companyLinkColor }}
+                >
+                  <Link
+                    href={companyHref}
+                    rel="noopener noreferrer nofollow"
+                    target="_blank"
+                  >
+                    {profile.companyName}
+                  </Link>
+                </Button>
+              ) : (
+                <span style={{ color: profile.companyLinkColor }}>
+                  {profile.companyName}
+                </span>
+              )}
+            </>
+          ) : null}
+        </p>
+        <p className="text-muted-foreground text-pretty">{profile.bio}</p>
+        <ProfileSocialStrip socials={socials} />
+        {hasMeta ? (
+          <div className="text-muted-foreground flex flex-col gap-2 pt-2 font-mono text-sm">
+            {profile.location ? (
+              <span className="flex items-center gap-2">
+                <FontAwesomeIcon
+                  icon={faLocationDot}
+                  className="size-3.5"
+                  aria-hidden
+                />
+                {profile.location}
+              </span>
+            ) : null}
+            {profile.disciplines.length > 0 ? (
+              <span className="flex items-center gap-2">
+                <FontAwesomeIcon
+                  icon={faBriefcase}
+                  className="size-3.5"
+                  aria-hidden
+                />
+                {profile.disciplines.join(' · ')}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Editar `profile-social-strip.tsx` — email vira mailto**
+
+Remover o import `import { EmailContactDialog } from '@/components/email-contact-dialog'` e o `import { cn } from '@/lib/utils'` se ficar sem uso. Definir a constante de contato no topo do arquivo:
+
+```ts
+const CONTACT_EMAIL = 'pilutechinformatica@gmail.com'
+```
+
+Substituir o bloco `<EmailContactDialog ...> ... </EmailContactDialog>` por:
+
+```tsx
+<Link
+  href={`mailto:${CONTACT_EMAIL}`}
+  className={squircleClass}
+  aria-label="Enviar email"
+>
+  {emailIcon ? (
+    <FontAwesomeIcon
+      icon={emailIcon}
+      className="text-foreground size-7"
+      aria-hidden
+    />
+  ) : null}
+</Link>
+```
+
+Trocar `rounded-2xl` por `rounded-xl` na `squircleClass` (estética V2).
+
+- [ ] **Step 3: Verificar + commit**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit` e `pnpm lint` → PASS. (Se `cn` ficou sem uso, remover o import pra não falhar o lint.)
+
+```bash
+git add apps/web/components/bio.tsx apps/web/components/profile-social-strip.tsx
+git commit -m "feat(web): restyle bio (status, meta) + social strip (email mailto) for V2"
+```
+
+---
+
+## Task 6: Reestilizar `job-card.tsx` (card + modal) (+ story)
+
+**Files:**
+
+- Modify: `apps/web/components/job-card.tsx`
+- Create: `apps/web/components/job-card.stories.tsx`
+
+- [ ] **Step 1: Substituir `job-card.tsx`**
+
+```tsx
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Carreira } from '@/mocks/carreira'
+import Link from 'next/link'
+
+export function JobCard(props: Carreira) {
+  const logo = (
+    <Avatar className="bg-accent-soft size-10 shrink-0 rounded-md">
+      {props.image && (
+        <AvatarImage src={props.image} alt={props.orgName + ' Logo'} />
+      )}
+      <AvatarFallback className="bg-accent-soft text-primary rounded-md text-xs font-bold">
+        {props.altImage}
+      </AvatarFallback>
+    </Avatar>
+  )
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="group bg-card border-border hover:bg-accent flex w-full cursor-pointer flex-col gap-3 rounded-lg border p-5 text-left transition-colors"
+        >
+          <div className="flex items-center gap-3">
+            {logo}
+            <div className="flex flex-col">
+              <span className="leading-tight font-semibold">
+                {props.orgName}
+              </span>
+              <span className="text-muted-foreground font-mono text-xs">
+                {props.date}
+              </span>
+            </div>
+          </div>
+          <p className="text-sm">{props.title}</p>
+          <div className="flex flex-wrap items-center gap-2">
+            {props.current ? (
+              <span className="border-border inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs">
+                <span className="bg-ok size-1.5 rounded-full" aria-hidden />
+                Atual
+              </span>
+            ) : null}
+            {props.tags.map((tag) => (
+              <span
+                key={tag}
+                className="border-border rounded-full border px-2.5 py-0.5 text-xs"
+              >
+                {tag}
+              </span>
+            ))}
+            <span className="text-primary ml-auto font-mono text-xs">
+              detalhes →
+            </span>
+          </div>
+        </button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <div className="flex items-start gap-4">
+            {logo}
+            <div className="flex flex-col gap-1">
+              <DialogTitle className="text-xl">{props.orgName}</DialogTitle>
+              <p className="text-muted-foreground font-mono text-xs">
+                {props.title} · {props.date}
+              </p>
+            </div>
+          </div>
+          <DialogDescription className="text-primary pt-2 text-base">
+            {props.orgDescription}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <p className="text-muted-foreground font-mono text-xs tracking-[0.2em] uppercase">
+            Atribuições
+          </p>
+          <ul className="flex flex-col gap-3">
+            {props.atribuitions.map((atribuicao) => (
+              <li key={atribuicao} className="flex gap-3 text-sm">
+                <span
+                  className="bg-primary mt-1.5 size-1.5 shrink-0 rounded-[2px]"
+                  aria-hidden
+                />
+                <span>{atribuicao}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {props.orgLink.trim() ? (
+          <DialogFooter>
+            <Button asChild className="w-full">
+              <Link
+                href={props.orgLink}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Saiba mais sobre {props.orgName}
+              </Link>
+            </Button>
+          </DialogFooter>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: Criar a story**
+
+`apps/web/components/job-card.stories.tsx`:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { JobCard } from './job-card'
+
+const meta: Meta<typeof JobCard> = {
+  title: 'Home/JobCard',
+  component: JobCard,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div className="w-[360px]">
+        <Story />
+      </div>
+    ),
+  ],
+}
+export default meta
+type Story = StoryObj<typeof JobCard>
+
+const base = {
+  id: 'viralizeplus',
+  orgName: 'ViralizePlus',
+  orgDescription: 'Sua comunidade de desenvolvimento open source.',
+  orgLink: 'https://www.viralizeplus.com.br/',
+  altImage: 'V+',
+  title: 'Site Reliability Engineer',
+  location: 'Remoto',
+  date: 'Dez 2024 — Atual',
+  atribuitions: [
+    'Reestruturação das entregas com GitHub Actions, acelerando releases em ~60%.',
+    'Eficiência na AWS com economia de ~40% na fatura mensal.',
+    'Monitoramento com Grafana e Prometheus para visibilidade 24/7.',
+  ],
+  current: true,
+  tags: ['Remoto'],
+}
+
+export const Atual: Story = { args: base }
+export const Passado: Story = {
+  args: { ...base, current: false, date: 'Dez 2023 — Out 2024', tags: [] },
+}
+```
+
+- [ ] **Step 3: Verificar + commit**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit` e `pnpm lint` → PASS.
+
+```bash
+git add apps/web/components/job-card.tsx apps/web/components/job-card.stories.tsx
+git commit -m "feat(web): restyle JobCard card + career detail modal (V2)"
+```
+
+---
+
+## Task 7: Reestilizar `project-card.tsx` (+ story)
+
+**Files:**
+
+- Modify: `apps/web/components/project-card.tsx`
+- Create: `apps/web/components/project-card.stories.tsx`
+
+- [ ] **Step 1: Substituir `project-card.tsx`**
+
+```tsx
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import { Project } from '@/mocks/projects'
+import { faCode } from '@fortawesome/free-solid-svg-icons'
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import Link from 'next/link'
+
+type ProjectCardProps = Project & {
+  className?: string
+}
+
+export function ProjectCard(props: ProjectCardProps) {
+  const { className, ...project } = props
+
+  return (
+    <Card
+      className={cn(
+        'bg-card border-border flex flex-col gap-5 rounded-lg p-6',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-4">
+        <Avatar className="bg-accent-soft size-12 shrink-0 rounded-lg">
+          {project.image && (
+            <AvatarImage
+              src={project.projectLogo}
+              alt={project.projectName + ' Logo'}
+            />
+          )}
+          <AvatarFallback className="bg-accent-soft text-primary rounded-lg font-bold">
+            {project.altImage}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex flex-col">
+          <h3 className="text-xl font-bold">{project.projectName}</h3>
+          {project.subtitle ? (
+            <p className="text-muted-foreground text-sm">{project.subtitle}</p>
+          ) : null}
+        </div>
+      </div>
+
+      <p className="text-muted-foreground" title={project.description}>
+        {project.description}
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        {project.tags.map((tag) => (
+          <span
+            key={tag}
+            className="border-border rounded-full border px-2.5 py-0.5 font-mono text-xs"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        {project.deployLink ? (
+          <Button asChild>
+            <Link
+              href={project.deployLink}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <FontAwesomeIcon
+                icon={faArrowUpRightFromSquare}
+                className="size-3.5"
+              />
+              Demo
+            </Link>
+          </Button>
+        ) : null}
+        {project.repoLink ? (
+          <Button asChild variant="outline">
+            <Link
+              href={project.repoLink}
+              rel="noopener noreferrer nofollow"
+              target="_blank"
+            >
+              <FontAwesomeIcon icon={faCode} className="size-3.5" />
+              Código
+            </Link>
+          </Button>
+        ) : null}
+      </div>
+    </Card>
+  )
+}
+```
+
+- [ ] **Step 2: Criar a story**
+
+`apps/web/components/project-card.stories.tsx`:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { ProjectCard } from './project-card'
+
+const meta: Meta<typeof ProjectCard> = {
+  title: 'Home/ProjectCard',
+  component: ProjectCard,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+}
+export default meta
+type Story = StoryObj<typeof ProjectCard>
+
+const base = {
+  id: 'live-prs',
+  projectName: 'Live PRs',
+  subtitle: 'agregador de pull requests',
+  projectLogo: '/pr-live-dark.svg',
+  description:
+    'Agrega os pull requests em que sua revisão foi solicitada, por repositório ou organização. Reúne tudo em cards com estado do PR, checks de CI e assignees.',
+  tags: ['React', 'Next', 'Go', 'Tailwind', 'Docker', 'AWS', 'Grafana'],
+  deployLink: 'https://example.com',
+  repoLink: 'https://github.com/example',
+  altImage: 'LPR',
+}
+
+export const Default: Story = { args: base }
+export const SemSubtitulo: Story = {
+  args: { ...base, subtitle: '', repoLink: '' },
+}
+```
+
+- [ ] **Step 3: Verificar + commit**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit` e `pnpm lint` → PASS. (Ajustar o mock da story até o `tsc` passar — o type `Project` exige `subtitle`.)
+
+```bash
+git add apps/web/components/project-card.tsx apps/web/components/project-card.stories.tsx
+git commit -m "feat(web): restyle ProjectCard (icon, subtitle, stack, Demo/Código) for V2"
+```
+
+---
+
+## Task 8: Reestilizar `article-card.tsx` (+ index via `article-section.tsx`)
+
+**Files:**
+
+- Modify: `apps/web/components/article-card.tsx`
+- Modify: `apps/web/components/article-section.tsx` (passar `index`)
+- Modify: `apps/web/components/article-card.stories.tsx` (passar `index`, refletir V2)
+
+Contexto: `ArticleCardView` tem `source: 'devto' | 'blog'`, `title`, `href`, `isExternal`, `readingTimeMinutes`. O `article-section.tsx` faz `initialBlogPosts.map((article) => <ArticleCard ... />)`.
+
+- [ ] **Step 1: Substituir `article-card.tsx`**
+
+```tsx
+import type { ArticleCardView } from '@/lib/article-feed'
+import { cn } from '@/lib/utils'
+import Link from 'next/link'
+
+type ArticleCardProps = {
+  article: ArticleCardView
+  index?: number
+  className?: string
+}
+
+export function ArticleCard({ article, index, className }: ArticleCardProps) {
+  const kbd = article.source === 'devto' ? '~/dev' : '~/blog'
+  const post = index !== undefined ? String(index + 1).padStart(2, '0') : null
+
+  return (
+    <Link
+      href={article.href}
+      target={article.isExternal ? '_blank' : undefined}
+      rel={article.isExternal ? 'noopener noreferrer nofollow' : undefined}
+      className={cn(
+        'group bg-card border-border flex h-full flex-col gap-4 rounded-lg border p-5 transition-colors',
+        'hover:bg-accent',
+        'focus-visible:ring-ring focus-visible:ring-offset-background outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 font-mono text-xs">
+        <span className="bg-accent-soft text-primary rounded px-1.5 py-0.5">
+          {kbd}
+        </span>
+        {post ? (
+          <span className="text-muted-foreground">· post {post}</span>
+        ) : null}
+      </div>
+      <h3 className="line-clamp-2 text-lg font-semibold">{article.title}</h3>
+      <div className="text-muted-foreground mt-auto flex items-center justify-between font-mono text-xs">
+        <span>{article.readingTimeMinutes} min de leitura</span>
+        <span className="text-primary transition-transform group-hover:translate-x-0.5">
+          ler →
+        </span>
+      </div>
+    </Link>
+  )
+}
+```
+
+- [ ] **Step 2: Substituir `article-section.tsx` (passar `index`)**
+
+```tsx
+import type { ArticleCardView } from '@/lib/article-feed'
+import { ArticleCard } from './article-card'
+
+type ArticleSectionProps = {
+  initialBlogPosts?: ArticleCardView[]
+}
+
+export function ArticleSection({ initialBlogPosts = [] }: ArticleSectionProps) {
+  return (
+    <>
+      {initialBlogPosts.map((article, i) => (
+        <ArticleCard key={article.id} article={article} index={i} />
+      ))}
+    </>
+  )
+}
+```
+
+- [ ] **Step 3: Atualizar `article-card.stories.tsx`**
+
+A story atual (`ComImagem` / `SemImagem`) testava a imagem/fallback que saíram no V2. Substituir as args pra refletir o card novo (adicionar `index`, remover dependência de imagem). Manter o `meta` (title `Blog/ArticleCard`, decorator `w-72`), e trocar as stories por:
+
+```tsx
+const baseArticle = {
+  id: 'blog-como-usar-husky',
+  source: 'blog' as const,
+  title: 'Como usar o Husky para garantir a qualidade do seu código',
+  href: '/posts/como-usar-husky',
+  isExternal: false,
+  socialImage: null,
+  readingTimeMinutes: 5,
+  reactionsCount: 0,
+  commentsCount: 0,
+  publishedAt: '2026-04-10T10:00:00.000Z',
+}
+
+export const Blog: Story = { args: { article: baseArticle, index: 0 } }
+export const DevTo: Story = {
+  args: {
+    article: {
+      ...baseArticle,
+      id: 'devto-1',
+      source: 'devto',
+      isExternal: true,
+    },
+    index: 1,
+  },
+}
+```
+
+- [ ] **Step 4: Verificar + commit**
+
+Run (em `apps/web/`): `pnpm exec tsc --noEmit` e `pnpm lint` → PASS.
+
+```bash
+git add apps/web/components/article-card.tsx apps/web/components/article-section.tsx apps/web/components/article-card.stories.tsx
+git commit -m "feat(web): restyle ArticleCard (kbd ~/blog, post NN, ler →) for V2"
+```
+
+---
+
+## Task 9: `page.tsx` (container 1180 + glow + profileName) + E2E + verificação final
+
+**Files:**
+
+- Modify: `apps/web/app/(site)/page.tsx`
+- Create: `apps/web/app/(site)/home.e2e.ts`
+- Modify: `CLAUDE.md` (registrar reskin da home)
+
+- [ ] **Step 1: Ajustar `page.tsx`**
+
+No JSX retornado:
+
+1. Adicionar o glow como primeiro filho do container raiz (antes do conteúdo):
+
+```tsx
+<div
+  aria-hidden
+  className="pointer-events-none fixed inset-x-0 top-0 -z-10 h-[600px] bg-[radial-gradient(60%_60%_at_50%_0%,var(--color-accent-soft),transparent)]"
+/>
+```
+
+2. Limitar a largura central a 1180px: no container raiz, trocar `2xl:max-w-[1920px]` por `2xl:max-w-[1180px]` (mantendo `2xl:mx-auto`).
+3. Simplificar o wrapper do perfil: o `<header className="flex flex-col gap-6">` em volta do `<Bio>` pode virar só `<Bio ... />` (o Bio já é um container com `gap-6`). Manter o `<main id="profile" ...>`.
+4. Passar `profileName={siteProfile.displayName}` ao `<HomeBentoLayout>`.
+
+- [ ] **Step 2: Criar smoke E2E da home**
+
+`apps/web/app/(site)/home.e2e.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test.describe('Home V2', () => {
+  test('mostra perfil, seções e abre o modal de carreira', async ({ page }) => {
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Paulo Victor/i }),
+    ).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Carreira' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Projetos' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Artigos' })).toBeVisible()
+
+    // abre o primeiro card de carreira -> modal
+    await page
+      .getByRole('button', { name: /detalhes/i })
+      .first()
+      .click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText('Atribuições', { exact: false })).toBeVisible()
+  })
+})
+```
+
+> Confirmar o padrão do Playwright do projeto (`playwright.config`, baseURL). Se a home depender de Keystatic/dev.to em build, o E2E roda contra o dev/preview server padrão do projeto. Ajustar selectors se necessário ao rodar.
+
+- [ ] **Step 3: Rodar a verificação completa**
+
+1. `pnpm prettier:fix`
+2. `pnpm lint` (em `apps/web/`)
+3. `pnpm exec tsc --noEmit` (em `apps/web/`)
+4. `pnpm --filter @piluvitu/web build`
+5. `pnpm --filter @piluvitu/web test` (Jest — deve seguir verde; sem lógica nova)
+6. (Opcional, se o ambiente permitir) `pnpm --filter @piluvitu/web test:e2e` para o smoke da home.
+
+- [ ] **Step 4: Atualizar `CLAUDE.md`**
+
+Na seção relevante (ex.: após a descrição da home/App Router), registrar que a home foi reestilizada pro DS V2: layout split-scroll (perfil fixo + bento rolável), `SectionHeader`/`HomeFooter`, cards V2, modal de carreira, e os campos novos do Keystatic (perfil: availability/location/disciplines; carreira: current/tags; projeto: subtitle) + link pra spec.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web CLAUDE.md
+git commit -m "feat(web): home V2 page container (1180 + glow), profile wiring, E2E smoke + docs"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- §3 layout/glow/maxw → Task 9 ✅
+- §4.1 section-header/home-footer → Tasks 2,3 ✅
+- §4.2 bento restyle → Task 4 ✅; bio → Task 5 ✅; social-strip (mailto) → Task 5 ✅; job-card card+modal → Task 6 ✅; project-card → Task 7 ✅; article-card → Task 8 ✅
+- §5 schema/readers/types/content → Task 1 ✅
+- §6 preservado (modal, visit-card, toggle; email→mailto) → Tasks 5,6 ✅
+- §9 verificação → Tasks (cada uma) + Task 9 ✅
+- §10 aceite → Task 9 Step 3/6 ✅
+
+**Placeholder scan:** sem TODO/TBD; todo passo de código tem código. (`article-section.tsx` Step 1 pede leitura porque o arquivo não foi colado aqui — Step 3 dá a edição concreta.)
+
+**Type/consistency:** `Carreira` ganha `current`/`tags` (Task 1) e são usados em job-card (Task 6) e mocks/stories; `Project` ganha `subtitle` usado em project-card (Task 7); `SiteProfileContent` ganha availability/location/disciplines usados em bio (Task 5) e fallback (Task 1). `HomeBentoLayout` ganha `profileName` (Task 4) passado em page.tsx (Task 9). Ordem das tasks garante que os tipos existam antes do uso.
+
+**Ordem recomendada:** 1 (dados) → 2,3 (novos) → 4 (bento) → 5,6,7,8 (cards) → 9 (page+verificação). Tasks 4-8 dependem da Task 1 (tipos) e 2/3 (componentes novos).

--- a/docs/superpowers/specs/2026-06-02-design-system-v2-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-02-design-system-v2-foundation-design.md
@@ -1,0 +1,238 @@
+# Design System V2 "Cloud (cyan)" — Fundação
+
+**Data:** 2026-06-02
+**Status:** Aprovado (design) — aguardando revisão da spec
+**Escopo:** Fundação (tokens + fontes + forma), sem reescrever páginas
+**Fonte de design:** Figma `V2-PiluVitu` — node `1:1870` ("1920w dark"), seção "Design System — Cloud (cyan)"
+
+---
+
+## 1. Objetivo
+
+Trocar a base visual do app do tema atual (shadcn **slate**, claro por padrão, `--primary` rosa, fonte Inter) para o **Design System V2 "Cloud (cyan)"**: dark-first, acento ciano, fontes Plus Jakarta Sans + JetBrains Mono, cards macios com sombra.
+
+A entrega é **fundacional**: reescrevemos os _valores_ dos tokens de tema e as fontes. Tudo que já consome os tokens shadcn (`bg-background`, `text-foreground`, `bg-primary`, `<Button>`, `<Card>`, `<Badge>`, etc.) herda o look novo automaticamente, **sem** reescrever páginas, estrutura de componentes ou copy.
+
+### Não-objetivos (fora do escopo desta fundação)
+
+- Reestilizar páginas individualmente (home, votação, tools, tasks, blog).
+- Introduzir as classes literais do Figma (`.btn`, `.card`, `.tag`, `.seg`). O repo usa shadcn/ui; mapeamos via tokens.
+- Mexer no `ThemeProvider` / toggle — **já existem e dark já é o default** (ver §7).
+- Criar/alterar lógica testável em Jest (fundação é CSS + config).
+
+---
+
+## 2. Decisões travadas (do brainstorming)
+
+| Decisão               | Escolha                                                                |
+| --------------------- | ---------------------------------------------------------------------- |
+| Alcance               | **Fundação primeiro**                                                  |
+| Tema padrão           | **Dark "Cloud" como padrão + variante light derivada** (toggle mantém) |
+| Arquitetura de tokens | **Mapear V2 → tokens shadcn existentes** + adicionar semânticos novos  |
+
+### Pegadinha de nomenclatura (crítica)
+
+No **V2**, `--accent` é a **cor de marca** (ciano). No **shadcn**, `--accent` é o _fundo sutil de hover_; a marca chama-se `--primary`. Portanto:
+
+- V2 `--accent` (ciano `#38bdf8`) → shadcn **`--primary`**
+- shadcn `--accent` (hover bg) → V2 `--surface-hover` `#18212f`
+
+Mapear "accent→accent" quebraria o tema inteiro. Esta spec usa o mapeamento correto acima.
+
+---
+
+## 3. Tokens — paleta dark (novo padrão, bloco `.dark`)
+
+Valores V2 convertidos para HSL-triplet (formato que o shadcn consome via `hsl(var(--token))`).
+
+| Token shadcn               | ← V2                           | Hex        | HSL-triplet   |
+| -------------------------- | ------------------------------ | ---------- | ------------- |
+| `--background`             | `--bg`                         | `#090c12`  | `220 33% 5%`  |
+| `--foreground`             | `--text`                       | `#e7ecf3`  | `215 33% 93%` |
+| `--card`                   | `--surface`                    | `#0f1420`  | `222 36% 9%`  |
+| `--card-foreground`        | `--text`                       | `#e7ecf3`  | `215 33% 93%` |
+| `--popover`                | `--surface`                    | `#0f1420`  | `222 36% 9%`  |
+| `--popover-foreground`     | `--text`                       | `#e7ecf3`  | `215 33% 93%` |
+| `--primary`                | `--accent` (marca)             | `#38bdf8`  | `198 93% 60%` |
+| `--primary-foreground`     | `--accent-ink`                 | `#04141c`  | `200 75% 6%`  |
+| `--secondary`              | `--surface-2`                  | `#141b2a`  | `221 35% 12%` |
+| `--secondary-foreground`   | `--text`                       | `#e7ecf3`  | `215 33% 93%` |
+| `--muted`                  | `--surface-2`                  | `#141b2a`  | `221 35% 12%` |
+| `--muted-foreground`       | `--text-dim`                   | `#93a0b3`  | `216 17% 64%` |
+| `--accent` (hover)         | `--surface-hover`              | `#18212f`  | `217 32% 14%` |
+| `--accent-foreground`      | `--text`                       | `#e7ecf3`  | `215 33% 93%` |
+| `--destructive`            | danger                         | `#f87171`  | `0 91% 71%`   |
+| `--destructive-foreground` | `--accent-ink`                 | `#04141c`  | `200 75% 6%`  |
+| `--border`                 | `--accent-line` (blend sólido) | ~`#163247` | `205 40% 18%` |
+| `--input`                  | idem                           | ~`#163247` | `205 40% 18%` |
+| `--ring`                   | `--accent`                     | `#38bdf8`  | `198 93% 60%` |
+
+**Nota sobre `--border`/`--input`:** o V2 usa `--accent-line = rgba(56,189,248,.32)` (linha ciano translúcida). Como o shadcn consome a borda via `hsl(var(--border))` (sem canal alpha), usamos a **cor sólida equivalente** ao blend de `accent-line` sobre `--surface` (`~205 40% 18%`). Valor exato afinado na implementação contra o screenshot.
+
+### Tokens semânticos novos (votação)
+
+Expostos como o `--success` de hoje (par `:root`/`.dark` + `@theme { --color-* }`). Hex confirmados 1:1 no Figma durante a implementação (lidos do screenshot da seção "Semânticas — Votação").
+
+| Token    | Significado (V2)   | Hex       | HSL-triplet   |
+| -------- | ------------------ | --------- | ------------- |
+| `--ok`   | seu voto · sucesso | `#34d399` | `158 64% 52%` |
+| `--warn` | empate · atenção   | `#fbbf24` | `43 96% 56%`  |
+| `--win`  | vencedor           | `#a78bfa` | `255 92% 76%` |
+
+- Foregrounds (`--ok-foreground`, `--warn-foreground`, `--win-foreground`): ink escuro `200 75% 6%` (texto sobre a cor).
+- `--success` é **mantido** com o mesmo valor de `--ok` (não quebra usos atuais de `text-success`); `--ok` passa a ser o nome canônico daqui pra frente.
+
+### Tokens de marca translúcidos (opcionais, com alpha)
+
+Expostos direto em `@theme` (têm canal alpha, então não viram triplet shadcn):
+
+```css
+@theme {
+  --color-accent-soft: rgb(
+    56 189 248 / 0.13
+  ); /* V2 --accent-soft → bg-accent-soft */
+  --color-accent-line: rgb(
+    56 189 248 / 0.32
+  ); /* V2 --accent-line → border-accent-line */
+}
+```
+
+Para fills/anéis de marca sutis (ex.: chip selecionado, ring de foco suave) quando uma página quiser, sem hardcode de hex.
+
+---
+
+## 4. Tokens — paleta light (derivada)
+
+O Figma só mostra o frame dark. Derivamos um light coerente: **mantém o ciano de marca**, inverte superfícies pra claro e texto pra escuro. Vai no bloco `:root` (light). Marcado como **derivado** — refinar se aparecer um frame light no Figma.
+
+| Token                     | Hex       | HSL-triplet   |
+| ------------------------- | --------- | ------------- |
+| `--background`            | `#f6f8fc` | `220 50% 98%` |
+| `--foreground`            | `#0f1420` | `222 36% 9%`  |
+| `--card` / `--popover`    | `#ffffff` | `0 0% 100%`   |
+| `--secondary` / `--muted` | `#eef2f8` | `216 42% 95%` |
+| `--accent` (hover)        | `#e6ecf5` | `216 43% 93%` |
+| `--muted-foreground`      | `#4a586b` | `215 18% 35%` |
+| `--primary`               | `#38bdf8` | `198 93% 60%` |
+| `--primary-foreground`    | `#04141c` | `200 75% 6%`  |
+| `--border` / `--input`    | —         | `216 30% 88%` |
+| `--ring`                  | `#38bdf8` | `198 93% 60%` |
+
+Semânticos no light: mesmos hues, luminosidade ajustada para contraste sobre fundo claro (afinado na implementação).
+
+---
+
+## 5. Tipografia
+
+Trocar **Inter → Plus Jakarta Sans** (texto e títulos) e adicionar **JetBrains Mono** (datas, labels, tags, metadados), ambos via `next/font/google`.
+
+**`app/layout.tsx`:**
+
+```ts
+import { Plus_Jakarta_Sans, JetBrains_Mono } from 'next/font/google'
+
+const sans = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-plus-jakarta',
+  display: 'swap',
+})
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains',
+  display: 'swap',
+})
+// <html className={`${sans.variable} ${mono.variable}`}>
+// body deixa de usar inter.className; passa a herdar font-sans
+```
+
+**`app/globals.css` (`@theme`):**
+
+```css
+@theme {
+  --font-sans: var(--font-plus-jakarta), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-jetbrains), ui-monospace, monospace;
+}
+```
+
+No `globals.css`, a regra `body` existente (`@layer base { body { @apply bg-background text-foreground } }`) ganha **`@apply font-sans`**, e o `<body>` deixa de receber `inter.className`. Assim o corpo herda Plus Jakarta Sans e `font-mono` (datas/labels/tags) renderiza JetBrains Mono em todo o app, como no V2.
+
+---
+
+## 6. Forma & sombra
+
+| Token           | Hoje             | V2                            | Ação                              |
+| --------------- | ---------------- | ----------------------------- | --------------------------------- |
+| `--radius`      | `0.75rem` (12px) | `--r-card` 18px               | `--radius: 1.125rem` (18px)       |
+| `--radius-pill` | —                | `--r-pill` 999px              | novo token p/ tags/badges/pílulas |
+| `--shadow-ds`   | —                | `--shadow` `0 18px 40px /.45` | novo token de sombra de card      |
+
+- `--radius: 18px` → escala shadcn lg=18 / md=16 / sm=14. Deixa inputs/botões mais arredondados — **proposital** pelo look macio do V2.
+- `--radius-pill` e `--shadow-ds` expostos via `@theme` (`--radius-pill`, `--shadow-ds`) para virarem utilitários `rounded-pill` / `shadow-ds`.
+
+```css
+@theme {
+  --radius-pill: 999px;
+  --shadow-ds: 0 18px 40px rgb(0 0 0 / 0.45);
+}
+```
+
+---
+
+## 7. Tema padrão & toggle (já existente — só verificar)
+
+- `next-themes@^0.4.6` **já é dependência**.
+- `components/theme-provider.tsx` envolve `app/(site)/layout.tsx` com `attribute="class" defaultTheme="dark" enableSystem`. **Dark já é o default**; `components/mode-toggle.tsx` já alterna.
+- Implicação de `enableSystem`: visitante com SO em modo claro vê a **variante light** — por isso a qualidade do light de §4 importa.
+- `ThemeProvider` cobre só as rotas `(site)`. Rotas fora dele (`/keystatic`, `/admin` do TinaCMS) renderizam sempre `:root` (light). Aceitável para a fundação; fora de escopo ajustar.
+
+Nenhuma mudança de código de tema aqui além de **confirmar** que o default dark continua e que os novos valores renderizam nos dois temas.
+
+---
+
+## 8. Arquivos afetados
+
+| Arquivo                                    | Mudança                                                                                                                                                                                                                                                               |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/web/app/globals.css`                 | Reescrever valores `:root` (light derivado) e `.dark` (V2 dark); adicionar `--ok/--warn/--win` (+ foregrounds), `--radius-pill`, `--shadow-ds`, `--color-accent-soft/-line`, `--font-sans/--font-mono`; ajustar `--radius`; manter `--success` como espelho de `--ok` |
+| `apps/web/app/layout.tsx`                  | Trocar Inter por Plus Jakarta Sans + JetBrains Mono; aplicar `.variable` no `<html>`; remover `inter.className` do `<body>`                                                                                                                                           |
+| `apps/web/components/*.stories.tsx` (nova) | Story "Design Tokens" mostrando paleta, fontes, raio e sombra (superfície de verificação visual)                                                                                                                                                                      |
+| `apps/web/components.json`                 | (verificar) `baseColor` segue `slate`; sem mudança funcional — tokens é que mudam                                                                                                                                                                                     |
+
+**Não tocar:** páginas, componentes de UI (estrutura), `ThemeProvider`, conteúdo Keystatic/Tina.
+
+---
+
+## 9. Riscos & mitigações
+
+| Risco                                                                                                         | Mitigação                                                                               |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Contraste insuficiente em algum par (ex.: `text-muted-foreground` sobre `--surface-2`)                        | Passada de verificação no Storybook + checar WCAG AA nos pares principais               |
+| `--radius: 18px` deixar inputs/botões redondos demais                                                         | Decisão proposital documentada; afinar na story se destoar do Figma                     |
+| Light derivado destoar de um eventual frame light oficial                                                     | Marcado como derivado; trivial de re-sincronizar depois                                 |
+| Hardcodes de cor existentes (ex.: `bg-amber-950` no banner de draft em `(site)/layout.tsx`) não herdam tokens | Fora de escopo; listar como follow-up de reskin                                         |
+| `--border` sólido perder o tom translúcido do V2                                                              | `--color-accent-line` disponível p/ bordas acentuadas; geral fica no sólido equivalente |
+
+---
+
+## 10. Verificação (regras do projeto)
+
+Ordem antes de concluir (CLAUDE.md):
+
+1. `pnpm prettier:fix`
+2. `pnpm lint` (ESLint + sem erros de tipo)
+3. `pnpm exec tsc --noEmit` (em `apps/web/`)
+4. `pnpm --filter @piluvitu/web build`
+5. Passada visual no **Storybook** (`pnpm --filter @piluvitu/web storybook`) — story "Design Tokens" + checar componentes shadcn (Button/Card/Badge/Input) nos temas dark e light.
+
+Fundação é CSS + config → **sem testes Jest novos** (não há lógica). A story de tokens é a superfície de verificação visual; E2E existentes não devem quebrar (sem mudança de DOM/estrutura).
+
+---
+
+## 11. Critérios de aceite
+
+- [ ] App renderiza no dark "Cloud (cyan)" por padrão; acento ciano `#38bdf8` visível em `<Button>`/links/foco.
+- [ ] Toggle "Tema" alterna para a variante light derivada sem quebra de contraste grosseira.
+- [ ] Fontes: corpo em Plus Jakarta Sans; `font-mono` em JetBrains Mono.
+- [ ] `--ok/--warn/--win` disponíveis como utilitários (`text-ok`, `bg-warn`, etc.); `text-success` antigo segue funcionando.
+- [ ] Cards com raio 18px e sombra `--shadow-ds`.
+- [ ] `lint` + `tsc --noEmit` + `build` verdes; Storybook abre e a story de tokens reflete a paleta.

--- a/docs/superpowers/specs/2026-06-02-home-v2-reskin-design.md
+++ b/docs/superpowers/specs/2026-06-02-home-v2-reskin-design.md
@@ -1,0 +1,215 @@
+# Home V2 "Cloud (cyan)" — Reskin da página inicial
+
+**Data:** 2026-06-02
+**Status:** Aprovado (design) — aguardando revisão da spec
+**Escopo:** Reskin da rota `/` (home) pro Design System V2, reusando dados e componentes
+**Depende de:** fundação DS V2 (branch `feat/design-system-v2-foundation` / PR #32) — tokens, fontes e semânticos já no `globals.css`
+**Fonte de design:** Figma `V2-PiluVitu` — node `1:450` (home "1920w dark") + modal de carreira (referência enviada pelo usuário)
+
+---
+
+## 1. Objetivo
+
+Reestilizar a home (`app/(site)/page.tsx` + componentes) pro layout V2: duas colunas (perfil fixo à esquerda, conteúdo rolável à direita) com seções **Carreira / Projetos / Artigos** usando headers padronizados (label mono + contador + régua), cards DS V2, e footer. Os **dados continuam vindo do Keystatic** (perfil, socials, carreiras, projetos) e do blog/dev.to (artigos). Reusa e reestiliza os componentes atuais; não reescreve wiring de dados.
+
+### Não-objetivos
+
+- Mudar de onde os dados vêm (Keystatic/blog continuam as fontes).
+- Reskin de outras rotas (votação, tools, tasks, blog) — fora desta entrega.
+- Trocar a infra de tema/toggle (já pronta na fundação).
+
+---
+
+## 2. Decisões travadas (brainstorming)
+
+| Decisão                | Escolha                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| Abordagem              | **Fiel ao V2, reusando dados + componentes**                                         |
+| Layout                 | Mantém a estrutura **bento** (`home-bento-layout.tsx` reestilizado, não substituído) |
+| Layout scroll          | **Esquerda fixa, direita rola** (mantém o split-scroll atual)                        |
+| Preservar              | **Modal de carreira** + **visit-card 3D** (triple-click avatar)                      |
+| Email na home          | Ícone vira **mailto** (dialog de email sai da home)                                  |
+| Cor da empresa         | Mantém o **`companyLinkColor`** configurável (role highlight vira ciano)             |
+| Tags da carreira       | **Campos próprios no Keystatic** (`current` + `tags[]`), não derivadas de string     |
+| Campos novos do perfil | **Adicionar ao Keystatic** (editáveis)                                               |
+| Subtítulo de projeto   | Campo **opcional** novo no Keystatic                                                 |
+
+---
+
+## 3. Layout & estrutura
+
+`app/(site)/page.tsx` usa **scroll da página inteira** (não overflow independente por coluna — esse modelo fazia o footer ficar pinado e estreito). Ajustes:
+
+- Container central **max 1180px** (`--maxw` do V2), padding lateral 40px (22px mobile).
+- Grid `xl:grid-cols-12` com **`xl:items-start`** (necessário pro sticky funcionar).
+- **Esquerda** (`xl:col-span-4`, **`xl:sticky xl:top-10 xl:self-start`**): `<Bio>`. Como é mais baixa que a viewport, fica fixa por todo o scroll.
+- **Direita** (`xl:col-span-8`, fluxo normal): `<HomeBentoLayout>` **reestilizado** (a home segue "bento") com as 3 seções. É o que "rola" (via scroll da página).
+- **Footer full-width:** `<HomeFooter>` fica **fora** do grid, abaixo dele, cobrindo as duas colunas; aparece no fim do scroll (não é pinado nem fica dentro da coluna direita).
+- **Glow ciano** no topo: um elemento de fundo absoluto com `radial-gradient`/`linear-gradient` usando `--color-accent-soft` (sutil, ~1200px de altura, atrás do conteúdo). Sem imagem.
+- **Mobile/tablet** (`< xl`): colunas empilham (perfil em cima, conteúdo embaixo), 1 coluna nos grids. Mantém o comportamento responsivo atual.
+
+---
+
+## 4. Componentes
+
+Todos herdam os tokens DS V2 da fundação: `bg-background/bg-card`, `border-border`, `text-foreground/text-muted-foreground`, `bg-primary/text-primary` (ciano), `rounded-lg` (18px), `rounded-pill`, `shadow-ds`, `font-mono`, `--color-accent-soft/-line`.
+
+### 4.1 Criar
+
+**`components/section-header.tsx`** — header de seção reusável.
+
+- Props: `{ label: string; count?: number | string; id?: string }`.
+- Visual (Figma `div.sechead`, 17px de altura): `<h2>` com a `label` em **mono UPPERCASE**, `text-muted-foreground`, `tracking` largo, `text-xs/sm`; ao lado um `span.count` (`text-muted-foreground`, mono) com o número zero-padded (`05`, `01`, `06`); e uma **régua** 1px (`bg-border`, `flex-1`) preenchendo o resto, verticalmente centralizada. Gap ~12px.
+- `id` pro `aria-labelledby` da seção.
+
+> A home **continua "bento"**: o `home-bento-layout.tsx` **é mantido** e reestilizado no lugar (ver §4.2) — não criamos um componente substituto nem o apagamos.
+
+**`components/home-footer.tsx`** — `© {ano} {nome}` à esquerda; à direita `piluvitu.com.br · /tools · /votação · admin` (links reais pra `/tools`, `/votacao`, `/votacao/admin`). Mono, `text-muted-foreground`, borda-topo sutil. Componente separado (com story).
+
+### 4.2 Reestilizar (mantêm dados + comportamento)
+
+**`components/home-bento-layout.tsx`** — mantido (a home segue "bento"); reestilizado no lugar.
+
+- Cada uma das 3 `<section>` (Carreira/Projetos/Artigos) passa a usar `<SectionHeader label count>` no lugar do `<h2>` atual.
+- Renderiza `<HomeFooter>` ao final.
+- Grids seguem: Carreira/Artigos = 2-col (`xl:grid-cols-2`, gap ~14px), Projetos = 1-col largo; mobile = 1-col.
+- Contadores: `carreiraList.length`, `projectList.length`, nº de artigos (zero-padded, ex. `String(n).padStart(2, '0')`).
+- Mantém as props atuais (`carreiraList`, `projectList`, `initialBlogPosts`); o nome/arquivo do componente **não muda**.
+
+**`components/bio.tsx`** — coluna de perfil (Figma `PERFIL`).
+
+- Topo: avatar (imagem do perfil; `ProfileVisitCard` **mantido** — triple-click abre o card 3D) + `<ModeToggle>` ("Tema") à direita.
+- `● Disponível para oportunidades` (dot `bg-ok` + texto mono) — vem do novo campo `availability` (§5).
+- `<h1>` nome **grande** (`text-4xl/5xl`, `font-sans` bold, `tracking-tight`) — 2 linhas como no Figma.
+- Cargo: `roleHighlight` em **ciano** (`text-primary`, troca a cor lima hardcoded `text-lime-500` que destoa do tema) + " na " + link da empresa. O nome da empresa **mantém o `companyLinkColor`** configurável do Keystatic (cor custom por empresa, inline) — não é forçado pro ciano.
+- Bio (`text-muted-foreground`).
+- `<ProfileSocialStrip>` (abaixo).
+- Meta (novo, §5): linha `📍 {location}` e `💼 {disciplines.join(' · ')}` em mono, ícones FA.
+
+**`components/profile-social-strip.tsx`** — botões-ícone V2 (42×42, `rounded-lg`/`rounded-xl`, `bg-card` hover `bg-accent`, ícone `text-muted-foreground` hover `text-foreground`). Email = link **mailto** (sem dialog).
+
+**`components/job-card.tsx`** — card + modal de carreira.
+
+- **Card** (`article.card`, 353×141, padding ~19px, `bg-card border-border rounded-lg`): topo = logo quadrado 40×40 (`rounded-md`, `bg-accent-soft text-primary`, abreviatura `altImage`) + empresa (`orgName`, semibold) e data (`date`, mono `text-muted-foreground`); cargo (`title`); rodapé = tags **vindas de campos próprios do Keystatic** (§5.3): `current` (checkbox) → pill "Atual" com dot; `tags[]` → demais pills (ex. "Remoto"), todas `rounded-pill border` — + "detalhes →" (`text-primary`, abre o modal).
+- **Modal** (referência Image #1, `Dialog` do shadcn já usado): head = logo + título `orgName` + "{title} · {date}" mono + botão fechar; tagline ciano (`orgDescription`, `text-primary`); label **ATRIBUIÇÕES** (mono uppercase, `text-muted-foreground`); lista `atribuitions` com **marcadores quadrados ciano** (`bg-primary`); footer = botão primário full-width "Saiba mais sobre {orgName}" (quando `orgLink`).
+
+**`components/project-card.tsx`** — card de projeto V2 (Figma `Projetos`, padding 25px).
+
+- Head: ícone 48×48 (`rounded-lg bg-accent-soft text-primary`, `projectLogo`/FA) + título (`projectName`) + subtítulo (`subtitle` novo, opcional — `text-muted-foreground`, omite se vazio).
+- Descrição (`description`).
+- Stack: `tags[]` como `rounded-pill border` mono.
+- Links: `Demo` (botão **primário** ciano → `deployLink`) + `Código` (botão **ghost/outline** → `repoLink`), com ícones. Omite cada um se o link faltar.
+
+**`components/article-card.tsx`** — card de artigo V2 (`a.card`, 353×135, padding ~21px).
+
+- Meta: `span.kbd` `~/blog` (mono, `bg-accent-soft`/borda, `text-primary`) + `· post {NN}` (índice zero-padded).
+- Título (`text-foreground`, 2 linhas, `line-clamp-2`).
+- Rodapé: `{readingTimeMinutes} min de leitura` (mono `text-muted-foreground`) + "ler →" (`text-primary`). Card inteiro é link pro artigo (`url`).
+- Mantém o feed atual (dev.to + blog via `ArticleSection`/TanStack Query).
+
+---
+
+## 5. Dados / Keystatic (migração de schema)
+
+> Migração de schema do Keystatic = mudança em `keystatic.config.ts` + reader + valores no `content/`. O agente **não roda migração**; informa o passo. Aqui é schema declarativo (sem SQL) — o "migrar" é só editar a config + preencher o YAML inicial.
+
+### 5.1 `siteProfile` singleton (`keystatic.config.ts`)
+
+Adicionar campos:
+
+- `availabilityOpen: fields.checkbox({ label: 'Disponível para oportunidades', defaultValue: true })`
+- `availabilityLabel: fields.text({ label: 'Texto de disponibilidade', defaultValue: 'Disponível para oportunidades' })`
+- `location: fields.text({ label: 'Local', description: 'Ex.: Brasil · Remoto' })`
+- `disciplines: fields.array(fields.text({ label: 'Disciplina' }), { label: 'Disciplinas', itemLabel: (p) => p.value })` (ex.: SRE, DevOps, Cloud)
+
+`SiteProfileContent` (`lib/site-content.ts`) ganha: `availabilityOpen: boolean`, `availabilityLabel: string`, `location: string`, `disciplines: string[]`. `getSiteProfile` lê os novos campos (com defaults seguros caso ausentes). O `fallbackProfile` em `page.tsx` ganha valores padrão (Brasil · Remoto, SRE/DevOps/Cloud, disponível=true).
+
+### 5.2 `projects` collection — subtítulo
+
+Adicionar `subtitle: fields.text({ label: 'Subtítulo', description: 'Ex.: agregador de pull requests' })` (opcional). `Project` type ganha `subtitle?: string`; reader (`getProjects`) inclui; card omite quando vazio.
+
+### 5.3 `carreiras` collection — tags próprias
+
+Adicionar campos (substituem a derivação por string):
+
+- `current: fields.checkbox({ label: 'Cargo atual', defaultValue: false })` — dirige a pill "Atual" (com dot).
+- `tags: fields.array(fields.text({ label: 'Tag' }), { label: 'Tags', itemLabel: (p) => p.value })` — ex.: "Remoto", "Híbrido".
+
+`Carreira` type (`mocks/carreira.ts`) ganha `current: boolean` e `tags: string[]`; `getCarreiras` lê os novos campos (defaults seguros: `current=false`, `tags=[]`). O card renderiza "Atual" se `current`, seguido de cada `tag`.
+
+### 5.4 Conteúdo inicial
+
+Preencher o YAML do `content/site/profile/` (status, local, disciplinas), `content/carreiras/*` (`current`/`tags`) e (opcional) `subtitle` em `content/projects/*` com os valores atuais. Como o Keystatic grava commitando, na prática edito os arquivos YAML no repo (status disponível, "Brasil · Remoto", disciplinas SRE/DevOps/Cloud, `current=true` nos cargos vigentes, tag "Remoto" onde couber).
+
+---
+
+## 6. Comportamentos preservados / removidos
+
+| Item                                | Decisão                                           |
+| ----------------------------------- | ------------------------------------------------- |
+| Modal de detalhes da carreira       | **Mantido** (reestilizado p/ Image #1)            |
+| Visit-card 3D (triple-click avatar) | **Mantido** (ProfileVisitCard segue no Bio)       |
+| Theme toggle ("Tema")               | **Mantido** (ModeToggle)                          |
+| Feed de artigos (dev.to + blog)     | **Mantido** (ArticleSection/TanStack Query)       |
+| Dialog de contato por email         | **Removido da home** — ícone Email vira `mailto:` |
+
+---
+
+## 7. Arquivos afetados
+
+| Arquivo                                                               | Ação                                                                                                      |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `app/(site)/page.tsx`                                                 | Ajustar container (maxw 1180, glow), novos campos no `fallbackProfile` (mantém `HomeBentoLayout`)         |
+| `components/section-header.tsx` (+ `.stories.tsx`)                    | **Criar**                                                                                                 |
+| `components/home-footer.tsx` (+ `.stories.tsx`)                       | **Criar**                                                                                                 |
+| `components/home-bento-layout.tsx`                                    | **Reestilizar** (section-headers + footer; mantido — não remover)                                         |
+| `components/bio.tsx`                                                  | Reestilizar (status, nome, cargo ciano, empresa mantém `companyLinkColor`, meta rows)                     |
+| `components/profile-social-strip.tsx`                                 | Reestilizar (botões-ícone, email mailto)                                                                  |
+| `components/job-card.tsx` (+ `.stories.tsx`)                          | Reestilizar card + modal; tags de `current`/`tags[]`                                                      |
+| `components/project-card.tsx` (+ `.stories.tsx`)                      | Reestilizar                                                                                               |
+| `components/article-card.tsx` (já tem story)                          | Reestilizar                                                                                               |
+| `keystatic.config.ts`                                                 | Campos novos: siteProfile (status/local/disciplinas), carreiras (`current`/`tags`), projects (`subtitle`) |
+| `lib/site-content.ts`                                                 | `SiteProfileContent` + `getSiteProfile`; `getCarreiras` (novos campos)                                    |
+| `mocks/projects.ts`                                                   | `subtitle?`                                                                                               |
+| `mocks/carreira.ts`                                                   | `current: boolean`, `tags: string[]`                                                                      |
+| `content/site/profile/*`, `content/carreiras/*`, `content/projects/*` | Valores iniciais dos campos novos                                                                         |
+
+**Não tocar:** rotas votação/tools/tasks/blog; infra de tema; `ProfileVisitCard` (lógica do 3D).
+
+---
+
+## 8. Riscos & mitigações
+
+| Risco                                                 | Mitigação                                                                                                       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Avatar no Figma mostra estado de upload do CMS        | Na home real usa `avatarSrc` (imagem); estado de upload é só do Keystatic                                       |
+| Campos novos do Keystatic ausentes em conteúdo antigo | Defaults seguros no reader (`current=false`, `tags=[]`, status/local/disciplinas opcionais) + `fallbackProfile` |
+| Split-scroll + glow causar overflow/scroll duplo      | Testar nos breakpoints; glow é `pointer-events-none` atrás do conteúdo                                          |
+| Stories quebrarem por novos campos obrigatórios       | Campos novos são opcionais/têm default; atualizar mocks das stories afetadas                                    |
+| Reestilização do bento mudar a estrutura de scroll    | Manter as 3 `<section>` e props do `home-bento-layout.tsx`; só trocar `<h2>`→`<SectionHeader>` e cards          |
+
+---
+
+## 9. Verificação (regras do projeto)
+
+1. `pnpm prettier:fix`
+2. `pnpm lint` (em `apps/web/`)
+3. `pnpm exec tsc --noEmit` (em `apps/web/`)
+4. `pnpm --filter @piluvitu/web build`
+5. **Storybook**: stories novas/atualizadas (section-header, job-card, project-card, article-card, bio) nos temas dark/light.
+6. **E2E**: smoke da home (`app/(site)/home.e2e.ts` se existir/criar) — perfil, seções, abrir modal de carreira, links. Não depende de API.
+7. **Visual**: subir dev e conferir vs Figma (perfil fixo + conteúdo rola, glow, headers, cards, modal).
+
+Migração Keystatic: **informo o comando/passo**, não rodo (regra do projeto). Como é schema declarativo, o "passo" é revisar `keystatic.config.ts` e preencher o YAML — sem comando de DB.
+
+---
+
+## 10. Critérios de aceite
+
+- [ ] Home no layout V2: perfil fixo à esquerda, conteúdo rola à direita, glow ciano no topo.
+- [ ] Headers de seção com label mono + contador + régua (Carreira 0N / Projetos 0N / Artigos 0N).
+- [ ] Cards de carreira/projeto/artigo no visual V2; "detalhes →" abre o modal estilo Image #1.
+- [ ] Perfil mostra status, nome grande, cargo ciano "na {empresa}", bio, socials (email=mailto), meta (local + disciplinas) — campos novos editáveis no Keystatic.
+- [ ] Visit-card 3D (triple-click) e theme toggle seguem funcionando.
+- [ ] Footer com copyright + `piluvitu.com.br · /tools · /votação · admin`.
+- [ ] `lint` + `tsc` + `build` + `jest` verdes; stories e E2E da home passam.


### PR DESCRIPTION
## Summary

Fundação do **Design System V2 "Cloud (cyan)"** — dark-first, acento ciano. Mudança fundacional: só os valores dos tokens de tema e as fontes mudam; tudo que consome os tokens shadcn (`<Button>`, `<Card>`, `<Badge>`, `bg-primary`, `text-foreground`…) herda o look novo sozinho, **sem reescrever páginas**.

- **Tokens mapeados sobre o shadcn** em `app/globals.css`: a cor de marca do V2 (ciano `#38bdf8`) entra como `--primary` (no shadcn `--accent` é o hover bg, não a marca). `.dark` = "Cloud" dark; `:root` = variante light derivada. Dark já é o padrão (next-themes).
- **Fontes:** Inter → **Plus Jakarta Sans** (corpo/títulos) + **JetBrains Mono** (labels/datas/tags) via `next/font`, com fallback aninhado no `var()` (sobrevive ao Storybook).
- **Tokens semânticos novos** (votação): `--ok`/`--warn`/`--win` (`text-ok`/`bg-warn`/`text-win`). `--success` mantido como espelho de `--ok` (compat).
- **Marca translúcida** `--color-accent-soft`/`--color-accent-line`; **forma** `--radius` 18px + `--radius-pill` + `--shadow-ds`.
- **Story** `components/design-tokens.stories.tsx` como superfície de verificação visual.
- Spec + plano em `docs/superpowers/`.

## Test Plan

- [x] `tsc --noEmit` sem erros
- [x] `pnpm lint` (ESLint) limpo
- [x] `pnpm --filter @piluvitu/web build` — 30 rotas geradas (CSS `@theme`/`@apply` compila)
- [x] `jest` 11/11 passam
- [ ] **Visual** (revisor): abrir o preview da Vercel / Storybook e conferir dark "Cloud (cyan)" por padrão, toggle pro light derivado, fontes Plus Jakarta + JetBrains Mono, e a story "Design System / Tokens"
- [ ] Conferir contraste dos pares principais (foreground/background, `text-muted-foreground` em surfaces) nos dois temas

## Escopo

Entrega = **fundação** (tokens + fontes). Reskin página a página (home, votação, tools, tasks, blog) fica fora deste PR.